### PR TITLE
[feat](layout): 레이아웃/사이드/상단 바 UI 비율조정 및 하단바 생성

### DIFF
--- a/et --hard 23e3f94
+++ b/et --hard 23e3f94
@@ -1,0 +1,35 @@
+[33m9631317[m[33m ([m[1;36mHEAD[m[33m -> [m[1;32mfeat/layout-update[m[33m, [m[1;31morigin/feat/organizer-page[m[33m, [m[1;32mfeat/organizer-page[m[33m)[m [feat(layout)] : 레이아웃 구조 변경 및 하단바 신규 추가, 페이지 비율 수정
+[33m23e3f94[m [feat] : 회원가입 페이지 복구
+[33m29a10b3[m [feat] : 구독 페이지, 행사 상세페이지, 행사 카드 UI
+[33m2c955b6[m 이벤트 카드 UI 수정 및 상세페이지와 연결
+[33m7b5074f[m feat: HostDetail, EventCard UI 업데이트
+[33mde2436e[m design: 레이아웃 변경
+[33m485c915[m feat:구독 해제 기능 추가
+[33m6f938ce[m feat:카테고리, 한줄소개 삭제
+[33mb881b79[m design: 모바일 페이지 비율 수정
+[33m2a2996d[m chore(subscribe): endMessage 정리
+[33mf6b5897[m feat(subscribe): 구독 페이지, HostCard 컴포넌트, subscribe.css 추가
+[33m4fe97b2[m feat: 구독 페이지 구현 (SubscribePage)
+[33m72d2666[m[33m ([m[1;32mdevelop[m[33m)[m Merge pull request #44 from Likelion-13th-EGSBI/feat/mypage
+[33m032b703[m refactor: 마이페이지 구조변경
+[33me17936b[m Merge pull request #43 from Likelion-13th-EGSBI/feat/eventupload-ui
+[33m2192ec3[m Merge branch 'develop' into feat/eventupload-ui
+[33m68faed8[m design: 행사 등록 페이지 및 사이드바, 상단바 구현 완료
+[33m52f5b33[m Merge pull request #41 from Likelion-13th-EGSBI/feat/mypage
+[33m80b3c15[m 클래스명 수정
+[33mfc4aab4[m 마이페이지 구성 수정
+[33m41e6dc5[m Merge pull request #42 from Likelion-13th-EGSBI/chore/PR
+[33m0ef6311[m chore: PR 템플릿 수정
+[33md180730[m 페이지 디자인 세부사항 수정
+[33maace7b1[m 마이페이지 초기구성 완료
+[33md133b85[m Add Mypage.jsx
+[33m853faa1[m Merge pull request #40 from Likelion-13th-EGSBI/feat/auth-ui
+[33m1fc4629[m design: 로그인 및 회원가입 페이지 작업 완료
+[33m20d471a[m Merge pull request #8 from Likelion-13th-EGSBI/chore/projectrouteinit
+[33m78cfa00[m 🎉 chore: project 라우팅 설정 및 초기 파일 생성
+[33mcc040fb[m Merge pull request #2 from Likelion-13th-EGSBI/chore/reactinit
+[33ma774486[m  chore: react project init
+[33mbf708d1[m Merge pull request #1 from Likelion-13th-EGSBI/chore/template
+[33mc483984[m chore: PR 템플릿 수정
+[33m059a4eb[m chore: 이슈 및 PR 템플릿 생성
+[33m2169a53[m[33m ([m[1;31morigin/main[m[33m)[m Initial commit

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -10,8 +10,7 @@ import EventCard from './components/EventCard';
 import EventDetail from './pages/EventDetail';
 import HostCard from './components/HostCard';
 import HostDetail from './pages/HostDetail';
-
-
+import Sidebar from './components/Sidebar';
 
 function App() {
   return (

--- a/front/src/App.js
+++ b/front/src/App.js
@@ -1,34 +1,38 @@
+// src/App.js
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import './App.css';
+
+// Pages
 import LoginPage from './pages/LoginPage';
 import SignupPage from './pages/SignupPage';
 import EventUpload from './pages/EventUpload';
 import MyPage from './pages/MyPage';
 import SubscribePage from './pages/SubscribePage';
-import EventCard from './components/EventCard';
 import EventDetail from './pages/EventDetail';
-import HostCard from './components/HostCard';
 import HostDetail from './pages/HostDetail';
-import Sidebar from './components/Sidebar';
+
+import EventCard from './components/EventCard';
+import HostCard from './components/HostCard';
 
 function App() {
   return (
-    //페이지 라우팅
-    // 페이지가 추가될때마다 어떤 페이지인지 넣어주고 path에 url이 어떻게 보일지 작성
     <Router>
       <Routes>
         <Route path="/" element={<></>} />
+
         <Route path="/login" element={<LoginPage />} />
         <Route path="/signup" element={<SignupPage />} />
+
         <Route path="/event-upload" element={<EventUpload />} />
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/subscribe" element={<SubscribePage />} />
         <Route path="/host/:id" element={<HostDetail />} />
+        <Route path="/events/:id" element={<EventDetail />} />
+
         <Route path="/event-card" element={<EventCard />} />
         <Route path="/host-card" element={<HostCard />} />
-        <Route path="/events/:id" element={<EventDetail />} />
-        
+
 
       </Routes>
     </Router>

--- a/front/src/components/BottomBar.jsx
+++ b/front/src/components/BottomBar.jsx
@@ -1,0 +1,57 @@
+import React, { useMemo } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Home, MapPin, ThumbsUp, User, Plus } from 'lucide-react'; // ← Plus 추가
+import '../css/bottombar.css';
+
+export default function BottomBar() {
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+
+  const items = useMemo(
+    () => [
+      { id: 'home',         icon: Home,     label: '홈',   route: '/dashboard' },
+      { id: 'location',     icon: MapPin,   label: '위치', route: '/location' },
+      { id: 'event-upload', icon: Plus,     label: '업로드', route: '/event-upload' }, // ← 여기!
+      { id: 'subscribe',    icon: ThumbsUp, label: '구독', route: '/subscribe' },
+      { id: 'mypage',       icon: User,     label: '마이', route: '/mypage' },
+    ],
+    []
+  );
+
+  const routeToId = useMemo(
+    () =>
+      new Map([
+        ['/dashboard', 'home'],
+        ['/location', 'location'],
+        ['/event-upload', 'event-upload'],
+        ['/subscribe', 'subscribe'],
+        ['/mypage', 'mypage'],
+      ]),
+    []
+  );
+
+  const activeId = routeToId.get(pathname);
+
+  return (
+    <>
+      <nav className="bottombar" role="navigation" aria-label="하단 내비게이션">
+        {items.map(({ id, icon: Icon, label, route }) => (
+          <button
+            key={id}
+            type="button"
+            className={`bottombar-item ${activeId === id ? 'active' : ''}`}
+            onClick={() => navigate(route)}
+            aria-current={activeId === id ? 'page' : undefined}
+          >
+            <span className="bottombar-icon-wrap">
+              <Icon size={22} />
+            </span>
+            <span className="bottombar-label">{label}</span>
+            <span className="bottombar-indicator" aria-hidden="true" />
+          </button>
+        ))}
+      </nav>
+      <div className="bottombar-spacer" />
+    </>
+  );
+}

--- a/front/src/components/BottomBar.jsx
+++ b/front/src/components/BottomBar.jsx
@@ -1,57 +1,46 @@
+// src/components/BottomBar.jsx
 import React, { useMemo } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import { Home, MapPin, ThumbsUp, User, Plus } from 'lucide-react'; // ← Plus 추가
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Home, MapPin, PlusCircle, ThumbsUp, User } from 'lucide-react';
 import '../css/bottombar.css';
 
 export default function BottomBar() {
+  const location = useLocation();
   const navigate = useNavigate();
-  const { pathname } = useLocation();
 
   const items = useMemo(
     () => [
-      { id: 'home',         icon: Home,     label: '홈',   route: '/dashboard' },
-      { id: 'location',     icon: MapPin,   label: '위치', route: '/location' },
-      { id: 'event-upload', icon: Plus,     label: '업로드', route: '/event-upload' }, // ← 여기!
-      { id: 'subscribe',    icon: ThumbsUp, label: '구독', route: '/subscribe' },
-      { id: 'mypage',       icon: User,     label: '마이', route: '/mypage' },
+      { id: 'home', label: '홈',        icon: Home,      route: '/' },
+      { id: 'location', label: '위치',  icon: MapPin,    route: '/location' },   // 라우트 없으면 추가 필요
+      { id: 'event-upload', label: '업로드', icon: PlusCircle, route: '/event-upload' },
+      { id: 'subscriptions', label: '구독', icon: ThumbsUp, route: '/subscribe' },
+      { id: 'mypage', label: '마이',    icon: User,      route: '/mypage' },
     ],
     []
   );
 
-  const routeToId = useMemo(
-    () =>
-      new Map([
-        ['/dashboard', 'home'],
-        ['/location', 'location'],
-        ['/event-upload', 'event-upload'],
-        ['/subscribe', 'subscribe'],
-        ['/mypage', 'mypage'],
-      ]),
-    []
-  );
-
-  const activeId = routeToId.get(pathname);
+  const isActive = (route) => {
+    if (route === '/') return location.pathname === '/' || location.pathname === '/dashboard';
+    return location.pathname.startsWith(route);
+  };
 
   return (
-    <>
-      <nav className="bottombar" role="navigation" aria-label="하단 내비게이션">
-        {items.map(({ id, icon: Icon, label, route }) => (
-          <button
-            key={id}
-            type="button"
-            className={`bottombar-item ${activeId === id ? 'active' : ''}`}
-            onClick={() => navigate(route)}
-            aria-current={activeId === id ? 'page' : undefined}
-          >
-            <span className="bottombar-icon-wrap">
-              <Icon size={22} />
-            </span>
-            <span className="bottombar-label">{label}</span>
-            <span className="bottombar-indicator" aria-hidden="true" />
-          </button>
-        ))}
-      </nav>
-      <div className="bottombar-spacer" />
-    </>
+    <nav className="bottombar" aria-label="하단 내비게이션">
+      {items.map(({ id, label, icon: Icon, route }) => (
+        <button
+          key={id}
+          type="button"
+          className={`bottombar-item ${isActive(route) ? 'active' : ''}`}
+          onClick={() => navigate(route)}
+          aria-label={label}
+          aria-current={isActive(route) ? 'page' : undefined}
+        >
+          <span className="bottombar-icon-wrap">
+            <Icon size={22} aria-hidden />
+          </span>
+          <span className="bottombar-label">{label}</span>
+        </button>
+      ))}
+    </nav>
   );
 }

--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -1,38 +1,52 @@
-import React, { useState, useEffect } from 'react';
+// src/components/Layout.jsx
+import React, { useState, useEffect, useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import TopBar from './TopBar';
 import Sidebar from './Sidebar';
+import BottomBar from './BottomBar';
 import '../css/layout.css';
 
-const Layout = ({ 
-  children, 
-  pageTitle = "페이지 제목", 
-  activeMenuItem = "dashboard",
-  showLayout = true // 전체 레이아웃 표시 여부
-}) => {
-  const [isPc, setIsPc] = useState(window.innerWidth >= 1024);
+const Layout = ({ children, pageTitle = '페이지 제목', activeMenuItem, showLayout = true }) => {
+  const [isPc, setIsPc] = useState(() => window.innerWidth >= 1024);
+  const location = useLocation();
 
   useEffect(() => {
-    const handleResize = () => {
-      setIsPc(window.innerWidth >= 1024);
-    };
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    const onResize = () => setIsPc(window.innerWidth >= 1024);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
   }, []);
 
+  const routeToId = useMemo(
+    () =>
+      new Map([
+        ['/dashboard', 'home'],
+        ['/event-upload', 'event-upload'],
+        ['/subscribe', 'subscriptions'],
+        ['/bookmarks', 'bookmarks'],
+        ['/my-uploads', 'my-uploads'],
+        ['/my-participations', 'my-participations'],
+        ['/mypage', 'mypage'],
+        ['/location', 'location'],
+        ['/subscribepage', 'subscriptions'], // 과거 경로 호환
+      ]),
+    []
+  );
+
+  const resolvedActive = activeMenuItem || routeToId.get(location.pathname) || 'home';
+  const containerClass = `layout-container ${isPc ? 'pc' : 'mobile'}`;
+
   return (
-    <div className="layout-container">
+    <div className={containerClass}>
       {showLayout && (
         <>
-          {/* TopBar는 항상 표시 */}
-          <TopBar title={pageTitle} />
-
-          {/* Sidebar는 PC일 때만 표시 */}
-          {isPc && <Sidebar activeMenuItem={activeMenuItem} />}
+          <TopBar />
+          {isPc && <Sidebar activeMenuItem={resolvedActive} />}
+          {!isPc && <BottomBar />}
         </>
       )}
 
       <main className={`layout-main-content ${showLayout ? 'with-layout' : 'without-layout'}`}>
-        {children}
+        <div className="layout-inner">{children}</div>
       </main>
     </div>
   );

--- a/front/src/components/Layout.jsx
+++ b/front/src/components/Layout.jsx
@@ -16,9 +16,11 @@ const Layout = ({ children, pageTitle = '페이지 제목', activeMenuItem, show
     return () => window.removeEventListener('resize', onResize);
   }, []);
 
+  // 경로 → 메뉴 id 매핑
   const routeToId = useMemo(
     () =>
       new Map([
+        ['/', 'home'],
         ['/dashboard', 'home'],
         ['/event-upload', 'event-upload'],
         ['/subscribe', 'subscriptions'],
@@ -27,7 +29,9 @@ const Layout = ({ children, pageTitle = '페이지 제목', activeMenuItem, show
         ['/my-participations', 'my-participations'],
         ['/mypage', 'mypage'],
         ['/location', 'location'],
-        ['/subscribepage', 'subscriptions'], // 과거 경로 호환
+
+        // 과거 경로 호환
+        ['/subscribepage', 'subscriptions'],
       ]),
     []
   );
@@ -41,12 +45,16 @@ const Layout = ({ children, pageTitle = '페이지 제목', activeMenuItem, show
         <>
           <TopBar />
           {isPc && <Sidebar activeMenuItem={resolvedActive} />}
+          {/* ✅ 모바일에서만 하단바 렌더 */}
           {!isPc && <BottomBar />}
         </>
       )}
 
       <main className={`layout-main-content ${showLayout ? 'with-layout' : 'without-layout'}`}>
         <div className="layout-inner">{children}</div>
+
+        {/* ✅ 모바일에서만 하단바 높이만큼 여백 확보 */}
+        {!isPc && <div className="bottombar-spacer" />}
       </main>
     </div>
   );

--- a/front/src/components/Sidebar.jsx
+++ b/front/src/components/Sidebar.jsx
@@ -1,94 +1,101 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { Home, FileText, QrCode, Calendar, User, MapPin, LogOut, Bell } from 'lucide-react';
+// src/components/Sidebar.jsx
+import React, { useMemo } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
+import { Home, FileText, ThumbsUp, Heart, UploadCloud, CalendarCheck, User, MapPin, LogOut } from 'lucide-react';
+import logo from '../imgs/mainlogo.png';
 import '../css/sidebar.css';
 
-const Sidebar = ({ activeMenuItem = 'home' }) => {
-  const [activeMenu, setActiveMenu] = useState(activeMenuItem);
+const Sidebar = ({ activeMenuItem, user = { name: '김민지' } }) => {
   const navigate = useNavigate();
+  const location = useLocation();
 
-  // 사진 메뉴 전체 정리
-  const mainMenuItems = [
-    { id: 'home', icon: Home, label: '홈', route: '/dashboard' },
-    { id: 'event-upload', icon: FileText, label: '행사 등록', route: '/event-upload' },
-    { id: 'qr', icon: QrCode, label: 'QR 체크인', route: '/qr' },
-    { id: 'notifications', icon: Bell, label: '알림', route: '/notifications', badge: 3 },
+  const mainMenuItems = useMemo(
+    () => [
+      { id: 'home',              icon: Home,        label: '홈',               route: '/dashboard' },
+      { id: 'event-upload',      icon: FileText,    label: '행사 업로드',       route: '/event-upload' },
+      { id: 'subscriptions',     icon: ThumbsUp,    label: '구독',             route: '/subscribe' },
+      { id: 'bookmarks',         icon: Heart,       label: '내가 관심있는 행사', route: '/bookmarks' },
+      { id: 'my-uploads',        icon: UploadCloud, label: '내가 업로드한 행사', route: '/my-uploads' },
+      { id: 'my-participations', icon: CalendarCheck,label: '내가 참여한 행사',  route: '/my-participations' },
+    ],
+    []
+  );
+
+  const personalMenuItems = [
+    { id: 'mypage',   icon: User,   label: '마이페이지', route: '/mypage' },
+    { id: 'location', icon: MapPin, label: '위치 설정',  route: '/location' },
   ];
 
-  const myMenuItems = [
-    { id: 'mypage', icon: User, label: '마이페이지', route: '/mypage' },
-    { id: 'event-manage', icon: Calendar, label: '내 행사 관리', route: '/event-manage' },
-    { id: 'location', icon: MapPin, label: '위치 설정', route: '/location' },
-  ];
+  const routeToId = useMemo(() => {
+    const map = new Map();
+    [...mainMenuItems, ...personalMenuItems].forEach(m => map.set(m.route, m.id));
+    return map;
+  }, [mainMenuItems]);
 
-  const handleMenuClick = (menuId, route) => {
-    setActiveMenu(menuId);
-    if(route) navigate(route);
-  };
+  const activeFromPath = routeToId.get(location.pathname);
+  const active = activeMenuItem || activeFromPath || 'home';
+
+  const go = (route) => route && navigate(route);
 
   return (
-    <div className="sidebar-container">
-      {/* 사용자 정보 헤더 */}
-      <div className="sidebar-header">
-        <div className="sidebar-user-info">
-          <div className="sidebar-user-avatar">김</div>
+    <aside className="sidebar-container" aria-label="사이드바">
+      {/* 상단: 로고 + 프로필 */}
+      <div className="sidebar-top">
+        <div className="sidebar-brand" onClick={() => go('/dashboard')} role="button" tabIndex={0}>
+          <img src={logo} alt="서비스 로고" className="sidebar-logo" />
+        </div>
+
+        {/* ✅ 프로필 카드 (상단) */}
+        <div className="sidebar-user-card rich">
+          <div className="sidebar-user-avatar xl">김</div>
           <div className="sidebar-user-details">
-            <span className="sidebar-user-name">김민지</span>
+            <span className="sidebar-user-name xl">{user?.name ?? '사용자'}</span>
+            <span className="sidebar-meta-text strong">온라인</span>
           </div>
         </div>
       </div>
 
-      {/* 행사 등록 버튼(사진 기준 강조) */}
-      <div className="sidebar-section">
-        <button
-          className="sidebar-create-btn"
-          onClick={() => handleMenuClick('event-upload', '/event-upload')}
-        >
-          <FileText size={16} />
-          <span>행사 등록</span>
-        </button>
-      </div>
-
       {/* 메인 메뉴 */}
-      <nav className="sidebar-nav">
-        {mainMenuItems.map((item) => (
-          <div
-            key={item.id}
-            className={`sidebar-nav-item ${activeMenu === item.id ? 'active' : ''}`}
-            onClick={() => handleMenuClick(item.id, item.route)}
+      <nav className="sidebar-nav" aria-label="메인 메뉴">
+        {mainMenuItems.map(({ id, icon: Icon, label, route }) => (
+          <button
+            key={id}
+            type="button"
+            className={`sidebar-nav-item ${active === id ? 'active' : ''}`}
+            onClick={() => go(route)}
+            aria-current={active === id ? 'page' : undefined}
           >
-            <item.icon size={20} />
-            <span className="sidebar-nav-label">{item.label}</span>
-            {item.badge && (
-              <span className="sidebar-nav-badge">{item.badge}</span>
-            )}
-          </div>
+            <Icon size={18} />
+            <span className="sidebar-nav-label">{label}</span>
+          </button>
         ))}
       </nav>
 
-      {/* 개인 설정 및 행사 관리 메뉴 */}
-      <div className="sidebar-section">
-        <h3 className="sidebar-section-title">개인 설정</h3>
-        {myMenuItems.map((item) => (
-          <div
-            key={item.id}
-            className={`sidebar-nav-item ${activeMenu === item.id ? 'active' : ''}`}
-            onClick={() => handleMenuClick(item.id, item.route)}
+      {/* ✅ 개인 섹션 복구 */}
+      <div className="sidebar-section compact">
+        <h3 className="sidebar-section-title">개인</h3>
+        {personalMenuItems.map(({ id, icon: Icon, label, route }) => (
+          <button
+            key={id}
+            type="button"
+            className={`sidebar-nav-item ${active === id ? 'active' : ''}`}
+            onClick={() => go(route)}
+            aria-current={active === id ? 'page' : undefined}
           >
-            <item.icon size={20} />
-            <span className="sidebar-nav-label">{item.label}</span>
-          </div>
+            <Icon size={18} />
+            <span className="sidebar-nav-label">{label}</span>
+          </button>
         ))}
       </div>
 
       {/* 하단 로그아웃 */}
-      <div className="sidebar-footer">
-        <button className="sidebar-logout-btn" onClick={() => navigate('/login')}>
+      <div className="sidebar-bottom">
+        <button type="button" className="sidebar-logout-btn" onClick={() => go('/login')}>
           <LogOut size={16} />
           <span>로그아웃</span>
         </button>
       </div>
-    </div>
+    </aside>
   );
 };
 

--- a/front/src/components/Sidebar.jsx
+++ b/front/src/components/Sidebar.jsx
@@ -1,4 +1,4 @@
-// src/components/Sidebar.jsx
+
 import React, { useMemo } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { Home, FileText, ThumbsUp, Heart, UploadCloud, CalendarCheck, User, MapPin, LogOut } from 'lucide-react';
@@ -45,7 +45,7 @@ const Sidebar = ({ activeMenuItem, user = { name: '김민지' } }) => {
           <img src={logo} alt="서비스 로고" className="sidebar-logo" />
         </div>
 
-        {/* ✅ 프로필 카드 (상단) */}
+  
         <div className="sidebar-user-card rich">
           <div className="sidebar-user-avatar xl">김</div>
           <div className="sidebar-user-details">
@@ -71,7 +71,7 @@ const Sidebar = ({ activeMenuItem, user = { name: '김민지' } }) => {
         ))}
       </nav>
 
-      {/* ✅ 개인 섹션 복구 */}
+      {/* 개인 메뉴 */}
       <div className="sidebar-section compact">
         <h3 className="sidebar-section-title">개인</h3>
         {personalMenuItems.map(({ id, icon: Icon, label, route }) => (

--- a/front/src/components/TopBar.jsx
+++ b/front/src/components/TopBar.jsx
@@ -10,90 +10,73 @@ const TopBar = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    const handleResize = () => setIsMobile(window.innerWidth <= 768);
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    const onResize = () => setIsMobile(window.innerWidth <= 768);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
   }, []);
 
-  // switch문으로 경로별 제목 결정
-  const getTitle = (path) => {
-    switch (path) {
-      case '/':
-        return '메인페이지';
-      case '/event-upload':
-        return '행사 등록';
-      case '/profile':
-        return '내 프로필';
-      case '/settings':
-        return '설정';
-      // 필요에 따라 케이스 추가
-      default:
-        return '페이지 제목';
-    }
-  };
+  const isHome = location.pathname === '/' || location.pathname === '/dashboard';
+  const goBack = () => navigate(-1);
+  const goNotifications = () => navigate('/notifications');
+  const goQR = () => navigate('/qr');
 
-  const title = getTitle(location.pathname);
-
+  /* ===== 모바일 ===== */
   if (isMobile) {
-    if (location.pathname === '/') {
-      return (
-        <div className="topbar-mobile-container">
-          <div className="topbar-mobile-content">
-            <button className="topbar-mobile-btn topbar-mobile-qr">
-              <QrCode size={22} />
-            </button>
-            <div className="topbar-mobile-search">
-              <Search size={18} />
-              <input type="text" placeholder="행사 검색..." />
-            </div>
-            <button className="topbar-mobile-btn topbar-mobile-bell">
-              <Bell size={21} />
-              <span className="topbar-notification-badge">5</span>
-            </button>
-          </div>
-        </div>
-      );
-    } else {
-      return (
-        <div className="topbar-mobile-container">
-          <div className="topbar-mobile-content" style={{ justifyContent: 'flex-start' }}>
+    return (
+      <div className="topbar-mobile-container">
+        <div className="topbar-mobile-content">
+          {/* 좌측: 홈이면 로고, 그 외엔 뒤로가기 */}
+          {isHome ? (
             <button
-              className="topbar-mobile-btn"
-              onClick={() => navigate(-1)}
-              style={{ marginRight: 12 }}
-              aria-label="뒤로가기"
+              className="topbar-mobile-logo-btn"
+              aria-label="홈"
+              onClick={() => navigate('/dashboard')}
             >
+              <img src={logo} alt="로고" className="topbar-mobile-logo" />
+            </button>
+          ) : (
+            <button className="topbar-icon-btn" aria-label="뒤로가기" onClick={goBack}>
               <ArrowLeft size={22} />
             </button>
-            <h1 className="topbar-mobile-page-title">{title}</h1>
+          )}
+
+          {/* 중앙: 짧은 검색 (모바일 아이콘 20px 고정) */}
+          <div className="topbar-search topbar-search--mobile">
+            <Search size={20} className="topbar-search-icon" />
+            <input type="text" placeholder="검색" aria-label="검색" />
+          </div>
+
+          {/* 우측: 알림/QR */}
+          <div className="topbar-mobile-right">
+            <button className="topbar-icon-btn" aria-label="알림" onClick={goNotifications}>
+              <Bell size={20} />
+              <span className="topbar-badge">5</span>
+            </button>
+            <button className="topbar-icon-btn" aria-label="QR" onClick={goQR}>
+              <QrCode size={21} />
+            </button>
           </div>
         </div>
-      );
-    }
+      </div>
+    );
   }
 
-  // PC 레이아웃
+  /* ===== 데스크탑 ===== */
   return (
     <div className="topbar-container">
       <div className="topbar-content">
-        <div className="topbar-left">
-          <div className="topbar-logo">
-            <img src={logo} alt="로고" className="topbar-logo-img" />
-          </div>
-        </div>
         <div className="topbar-center">
-          <h1 className="topbar-page-title">{title}</h1>
+          <div className="topbar-search topbar-search--desktop">
+            <Search size={18} className="topbar-search-icon" />
+            <input type="text" placeholder="검색" aria-label="검색" />
+          </div>
         </div>
         <div className="topbar-right">
-          <div className="topbar-search-bar">
-            <Search size={18} />
-            <input type="text" placeholder="행사를 검색해보세요..." />
-          </div>
-          <button className="topbar-notification-btn">
+          <button className="topbar-icon-btn" aria-label="알림" onClick={goNotifications}>
             <Bell size={20} />
-            <span className="topbar-notification-badge">5</span>
+            <span className="topbar-badge">5</span>
           </button>
-          <button className="topbar-qr-btn">
+          <button className="topbar-icon-btn" aria-label="QR" onClick={goQR}>
             <QrCode size={22} />
           </button>
         </div>

--- a/front/src/css/bottombar.css
+++ b/front/src/css/bottombar.css
@@ -1,24 +1,26 @@
+/* src/css/bottombar.css */
 :root{
-  --brand: #5E936C;         /* 기본 브랜드 초록 */
-  --active: #939E91;        /* 선택(활성) 색상 */
-  --ink: #191f28;
+  --brand: #5E936C;         /* 기본 초록 */
+  --active: #939E91;        /* 선택 색상 */
   --muted: #6c757d;
   --line: #e9ecef;
-  --bottombar-height: 64px;
+  --bottombar-height: 64px; /* 하단바 높이 */
 }
 
 /* 기본 숨김 */
 .bottombar,
 .bottombar-spacer { display: none; }
 
-@media (max-width: 768px){
+/* ===== 모바일/태블릿(<=1023px)에서만 표시 ===== */
+@media (max-width: 1023px){
   .bottombar-spacer{
     display: block;
     height: calc(var(--bottombar-height) + env(safe-area-inset-bottom, 0px));
   }
 
   .bottombar{
-    position: fixed; left: 0; right: 0; bottom: 0;
+    position: fixed;
+    left: 0; right: 0; bottom: 0;
     height: var(--bottombar-height);
     background: #fff;
     border-top: 1px solid var(--line);
@@ -30,24 +32,34 @@
   }
 
   .bottombar-item{
-    appearance: none; border: none; background: transparent;
+    appearance: none;
+    border: none;
+    background: transparent;
     height: 100%;
-    display: flex; flex-direction: column; align-items: center; justify-content: center;
-    gap: 6px; color: var(--muted); font-size: 11px; min-width: 0;
+    display: flex; flex-direction: column;
+    align-items: center; justify-content: center;
+    gap: 6px;
+    color: var(--muted);
+    font-size: 11px;
   }
-  .bottombar-item svg{ width: 22px; height: 22px; stroke-width: 2; }
-  .bottombar-icon-wrap{ display: grid; place-items: center; }
-  .bottombar-label{ line-height: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 76px; }
 
-  /* 활성 상태 */
-  .bottombar-item.active{ color: var(--active); font-weight: 700; }
-  .bottombar-item.active svg{ stroke: var(--active); }
-  .bottombar-indicator{
-    width: 22px; height: 3px; border-radius: 3px; background: transparent; margin-top: 2px;
+  .bottombar-item .bottombar-icon-wrap{
+    display: grid; place-items: center;
+    width: 28px; height: 28px;
   }
-  .bottombar-item.active .bottombar-indicator{ background: var(--active); }
+
+  .bottombar-item.active{
+    color: var(--active);
+  }
+  .bottombar-item.active svg{ stroke: var(--active); }
+
+  .bottombar-label{ line-height: 1; user-select: none; }
 }
 
-@media (min-width: 769px){
-  .bottombar, .bottombar-spacer{ display: none !important; }
+/* 데스크탑(>=1024px)은 확실히 숨김 */
+@media (min-width: 1024px){
+  .bottombar,
+  .bottombar-spacer{
+    display: none !important;
+  }
 }

--- a/front/src/css/bottombar.css
+++ b/front/src/css/bottombar.css
@@ -1,0 +1,53 @@
+:root{
+  --brand: #5E936C;         /* 기본 브랜드 초록 */
+  --active: #939E91;        /* 선택(활성) 색상 */
+  --ink: #191f28;
+  --muted: #6c757d;
+  --line: #e9ecef;
+  --bottombar-height: 64px;
+}
+
+/* 기본 숨김 */
+.bottombar,
+.bottombar-spacer { display: none; }
+
+@media (max-width: 768px){
+  .bottombar-spacer{
+    display: block;
+    height: calc(var(--bottombar-height) + env(safe-area-inset-bottom, 0px));
+  }
+
+  .bottombar{
+    position: fixed; left: 0; right: 0; bottom: 0;
+    height: var(--bottombar-height);
+    background: #fff;
+    border-top: 1px solid var(--line);
+    display: grid;
+    grid-template-columns: repeat(5, 1fr);
+    align-items: center;
+    z-index: 1100;
+    padding-bottom: env(safe-area-inset-bottom, 0px);
+  }
+
+  .bottombar-item{
+    appearance: none; border: none; background: transparent;
+    height: 100%;
+    display: flex; flex-direction: column; align-items: center; justify-content: center;
+    gap: 6px; color: var(--muted); font-size: 11px; min-width: 0;
+  }
+  .bottombar-item svg{ width: 22px; height: 22px; stroke-width: 2; }
+  .bottombar-icon-wrap{ display: grid; place-items: center; }
+  .bottombar-label{ line-height: 1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; max-width: 76px; }
+
+  /* 활성 상태 */
+  .bottombar-item.active{ color: var(--active); font-weight: 700; }
+  .bottombar-item.active svg{ stroke: var(--active); }
+  .bottombar-indicator{
+    width: 22px; height: 3px; border-radius: 3px; background: transparent; margin-top: 2px;
+  }
+  .bottombar-item.active .bottombar-indicator{ background: var(--active); }
+}
+
+@media (min-width: 769px){
+  .bottombar, .bottombar-spacer{ display: none !important; }
+}

--- a/front/src/css/eventcard.css
+++ b/front/src/css/eventcard.css
@@ -60,34 +60,34 @@
 .bookmark-btn .icon { color: #fff; font-size: 18px; }
 .bookmark-btn.bookmarked .icon { color: #E74C3C; }
 
-/* ── 상단 이미지 영역 ─────────────────────── */
+/* ── 이벤트 이미지 ───────────────────────── */
 .event-image {
   width: 100%;
-  height: 180px;                       /* 기본 높이 */
+  height: 180px;                     
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #5E936C;                 /* 이미지 없을 때 초록색 */
+  background: #5E936C;                
 }
 
 .placeholder-text { color: #fff; font-size: 16px; font-weight: bold; }
 
-/* ── 하단 정보 영역 ─────────────────────── */
+/* ── 이벤트 정보 영역 ───────────────────── */
 .event-info {
   background: #fff;
   padding: 16px 14px;
 }
 
-/* 제목 */
+
 .event-title {
-  font-size: 16px;                     /* 필요시 18px까지 가능 */
+  font-size: 16px;                    
   font-weight: 700;
   margin-bottom: 8px;
   line-height: 1.25;
   color: #111;
-  white-space: nowrap;                 /* 한 줄 */
+  white-space: nowrap;               
   overflow: hidden;
-  text-overflow: ellipsis;             /* 너무 길면 … */
+  text-overflow: ellipsis;           
 }
 
 .event-summary {
@@ -116,12 +116,12 @@
   color: #333;
 }
 
-/* ── 모바일 최적화 ───────────────────────── */
+
 @media (max-width: 768px) {
-  /* 카드가 그리드 폭 안에서 꽉 차도록 */
+
   .event-card { width: 100%; border-radius: 10px; }
 
-  /* 이미지/버튼/텍스트 크기 축소 */
+
   .event-image { height: 132px; }
   .placeholder-text { font-size: 14px; }
 
@@ -133,14 +133,14 @@
 
   .event-info { padding: 12px 12px; }
 
-  /* 제목: 2줄까지만 보이기 + 더 작게 */
+ 
   .event-title {
     font-size: 14px;
     margin-bottom: 6px;
     line-height: 1.2;
     white-space: normal;
     display: -webkit-box;
-    -webkit-line-clamp: 2;           /* 2줄 클램프 */
+    -webkit-line-clamp: 2;      
     -webkit-box-orient: vertical;
   }
 
@@ -149,7 +149,7 @@
     margin-bottom: 6px;
     line-height: 1.35;
     display: -webkit-box;
-    -webkit-line-clamp: 2;           /* 2줄 클램프 */
+    -webkit-line-clamp: 2;         
     -webkit-box-orient: vertical;
   }
 
@@ -158,5 +158,5 @@
 
   .event-details { gap: 6px; }
   .detail-item  { font-size: 11px; gap: 4px; }
-  .detail-item svg { width: 14px; height: 14px; } /* react-icons 크기 축소 */
+  .detail-item svg { width: 14px; height: 14px; } 
 }

--- a/front/src/css/eventcard.css
+++ b/front/src/css/eventcard.css
@@ -1,9 +1,5 @@
-/* src/css/eventcard.css */
-
 /* 그리드가 hover 확장에 잘리지 않도록 */
-.event-grid {
-  overflow: visible;
-}
+.event-grid { overflow: visible; }
 
 /* ── 카드 기본 ───────────────────────────── */
 .event-card {
@@ -36,10 +32,7 @@
 }
 
 /* 블러 방지 */
-.event-card,
-.event-card * {
-  filter: none !important;
-}
+.event-card, .event-card * { filter: none !important; }
 
 /* ── 북마크 버튼 ─────────────────────────── */
 .bookmark-btn {
@@ -64,30 +57,20 @@
   box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
 }
 
-.bookmark-btn .icon {
-  color: #fff;
-  font-size: 18px;
-}
-
-.bookmark-btn.bookmarked .icon {
-  color: #E74C3C;
-}
+.bookmark-btn .icon { color: #fff; font-size: 18px; }
+.bookmark-btn.bookmarked .icon { color: #E74C3C; }
 
 /* ── 상단 이미지 영역 ─────────────────────── */
 .event-image {
   width: 100%;
-  height: 180px;                       /* 스샷 비율에 맞춘 높이 */
+  height: 180px;                       /* 기본 높이 */
   display: flex;
   align-items: center;
   justify-content: center;
   background: #5E936C;                 /* 이미지 없을 때 초록색 */
 }
 
-.placeholder-text {
-  color: #fff;
-  font-size: 16px;
-  font-weight: bold;
-}
+.placeholder-text { color: #fff; font-size: 16px; font-weight: bold; }
 
 /* ── 하단 정보 영역 ─────────────────────── */
 .event-info {
@@ -95,14 +78,14 @@
   padding: 16px 14px;
 }
 
-/* 제목: 스샷처럼 두껍고 가독성 있게 (8px → 복원) */
+/* 제목 */
 .event-title {
-  font-size: 16px;                     /* 필요하면 18px까지 가능 */
+  font-size: 16px;                     /* 필요시 18px까지 가능 */
   font-weight: 700;
   margin-bottom: 8px;
   line-height: 1.25;
   color: #111;
-  white-space: nowrap;                 /* 한 줄로 */
+  white-space: nowrap;                 /* 한 줄 */
   overflow: hidden;
   text-overflow: ellipsis;             /* 너무 길면 … */
 }
@@ -115,15 +98,8 @@
 }
 
 /* 해시태그 */
-.hashtags {
-  margin-bottom: 10px;
-}
-
-.hashtag {
-  font-size: 12px;
-  color: #5E936C;
-  margin-right: 6px;
-}
+.hashtags { margin-bottom: 10px; }
+.hashtag  { font-size: 12px; color: #5E936C; margin-right: 6px; }
 
 /* 상세 정보 2x2 */
 .event-details {
@@ -140,8 +116,47 @@
   color: #333;
 }
 
+/* ── 모바일 최적화 ───────────────────────── */
 @media (max-width: 768px) {
-  .event-card {
-    width: 100%;
+  /* 카드가 그리드 폭 안에서 꽉 차도록 */
+  .event-card { width: 100%; border-radius: 10px; }
+
+  /* 이미지/버튼/텍스트 크기 축소 */
+  .event-image { height: 132px; }
+  .placeholder-text { font-size: 14px; }
+
+  .bookmark-btn {
+    top: 8px; right: 8px;
+    width: 32px; height: 32px;
   }
+  .bookmark-btn .icon { font-size: 16px; }
+
+  .event-info { padding: 12px 12px; }
+
+  /* 제목: 2줄까지만 보이기 + 더 작게 */
+  .event-title {
+    font-size: 14px;
+    margin-bottom: 6px;
+    line-height: 1.2;
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;           /* 2줄 클램프 */
+    -webkit-box-orient: vertical;
+  }
+
+  .event-summary {
+    font-size: 12px;
+    margin-bottom: 6px;
+    line-height: 1.35;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;           /* 2줄 클램프 */
+    -webkit-box-orient: vertical;
+  }
+
+  .hashtags { margin-bottom: 8px; }
+  .hashtag  { font-size: 11px; margin-right: 6px; }
+
+  .event-details { gap: 6px; }
+  .detail-item  { font-size: 11px; gap: 4px; }
+  .detail-item svg { width: 14px; height: 14px; } /* react-icons 크기 축소 */
 }

--- a/front/src/css/eventdetail.css
+++ b/front/src/css/eventdetail.css
@@ -1,190 +1,482 @@
-/* src/css/eventdetail.css */
-
-/* 팔레트 변수 */
 .event-detail-container {
-  --cream: #F2ECD8;
-  --salmon: #F27B50;
-  --terracotta: #BF6341;
-  --espresso: #40180F;
-  --sage: #939E91;
+    --cream: #F2ECD8;
+    --salmon: #F27B50;
+    --terracotta: #BF6341;
+    --espresso: #40180F;
+    --sage: #939E91;
 
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 20px 20px 40px;
-  color: #333;
-  font-family: Arial, sans-serif;
+    max-width: 960px;
+    margin: 0 auto;
+    padding: 20px 20px 40px;
+    color: #333;
+    font-family: Arial, sans-serif;
+
+    /* 가로 스크롤 예방 */
+    overflow-x: hidden;
+    box-sizing: border-box;
+}
+
+.event-detail-container *,
+.event-detail-container *::before,
+.event-detail-container *::after {
+    box-sizing: inherit;
+}
+
+.event-detail-container img,
+.event-detail-container video {
+    max-width: 100%;
+    height: auto;
+    display: block;
 }
 
 /* ===== Hero ===== */
-.event-detail-container .ed-hero { margin-bottom: 12px; }
+.event-detail-container .ed-hero {
+    margin-bottom: 12px;
+}
+
 .event-detail-container .ed-cover {
-  width: 100%;
-  aspect-ratio: 16 / 9;
-  border-radius: 12px;
-  overflow: hidden;
-  background: #e7eee9;
-  box-shadow: 0 4px 14px rgba(0,0,0,0.06);
-  position: relative;
-  cursor: zoom-in;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    border-radius: 12px;
+    overflow: hidden;
+    background: #e7eee9;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.06);
+    position: relative;
+    cursor: zoom-in;
 }
+
 .event-detail-container .ed-cover.is-placeholder {
-  display: grid; place-items: center;
-  background: #5E936C; color: #fff; font-weight: 800; letter-spacing: 2px;
+    display: grid;
+    place-items: center;
+    background: #5E936C;
+    color: #fff;
+    font-weight: 800;
+    letter-spacing: 2px;
 }
-.event-detail-container .ed-cover img { width: 100%; height: 100%; object-fit: cover; }
+
+.event-detail-container .ed-cover img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
 .event-detail-container .ed-bookmark {
-  position: absolute; top: 12px; right: 12px;
-  width: 38px; height: 38px; display: grid; place-items: center;
-  background: rgba(0,0,0,0.35); border: 1px solid rgba(255,255,255,0.6);
-  border-radius: 50%; cursor: pointer; z-index: 2;
-  transition: transform .12s ease, background .12s ease, box-shadow .12s ease;
+    position: absolute;
+    top: 12px;
+    right: 12px;
+    width: 38px;
+    height: 38px;
+    display: grid;
+    place-items: center;
+    background: rgba(0, 0, 0, 0.35);
+    border: 1px solid rgba(255, 255, 255, 0.6);
+    border-radius: 50%;
+    cursor: pointer;
+    z-index: 2;
+    transition: transform .12s ease, background .12s ease, box-shadow .12s ease;
 }
+
 .event-detail-container .ed-bookmark:hover {
-  transform: translateY(-1px) scale(1.03);
-  background: rgba(0,0,0,0.45);
-  box-shadow: 0 4px 10px rgba(0,0,0,.25);
+    transform: translateY(-1px) scale(1.03);
+    background: rgba(0, 0, 0, 0.45);
+    box-shadow: 0 4px 10px rgba(0, 0, 0, .25);
 }
-.event-detail-container .ed-bookmark .icon { color:#fff; font-size:18px; }
-.event-detail-container .ed-bookmark.bookmarked .icon { color: var(--terracotta); }
-.event-detail-container .ed-cover-caption { font-size: 12px; color: var(--sage); margin-top: 6px; }
+
+.event-detail-container .ed-bookmark .icon {
+    color: #fff;
+    font-size: 18px;
+}
+
+.event-detail-container .ed-bookmark.bookmarked .icon {
+    color: var(--terracotta);
+}
+
+.event-detail-container .ed-cover-caption {
+    font-size: 12px;
+    color: var(--sage);
+    margin-top: 6px;
+}
 
 /* ===== 헤더 ===== */
-.event-detail-container .ed-head { margin-top: 8px; }
-.event-detail-container .event-title {
-  font-size: 2rem; color: #1f2d23; margin: 2px 0 8px; line-height: 1.25;
+.event-detail-container .ed-head {
+    margin-top: 8px;
 }
 
-/* 해시태그: 영/한 동일 크기/높이로 통일 */
-.event-detail-container .ed-tags { margin: 6px 0 8px; }
+.event-detail-container .event-title {
+    font-size: 2rem;
+    color: #1f2d23;
+    margin: 2px 0 8px;
+    line-height: 1.25;
+}
+
+/* 해시태그 */
+.event-detail-container .ed-tags {
+    margin: 6px 0 8px;
+}
+
 .event-detail-container .ed-tag {
-  display: inline-flex; align-items: center; justify-content: center;
-  font-size: 12px; font-weight: 700; line-height: 1;
-  color: #5E936C;
-  background: #eef5f0; border: 1px solid #d9e8de;
-  border-radius: 999px; padding: 6px 10px; margin-right: 6px;
-  letter-spacing: .2px; vertical-align: middle;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1;
+    color: #5E936C;
+    background: #eef5f0;
+    border: 1px solid #d9e8de;
+    border-radius: 999px;
+    padding: 6px 10px;
+    margin-right: 6px;
+    letter-spacing: .2px;
+    vertical-align: middle;
 }
 
 /* ===== 메타 2x2 ===== */
 .event-detail-container .ed-meta-grid.two-by-two {
-  display: grid; grid-template-columns: repeat(2, minmax(0,1fr));
-  gap: 16px; background: #fff;
-  border: 1px solid #e9eee9; border-radius: 12px;
-  padding: 16px; box-shadow: 0 2px 10px rgba(0,0,0,.04);
-  margin-bottom: 16px;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 16px;
+    background: #fff;
+    border: 1px solid #e9eee9;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, .04);
+    margin-bottom: 16px;
 }
+
 .event-detail-container .meta-item {
-  display: flex; align-items: flex-start; gap: 12px;
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
 }
-.event-detail-container .meta-item svg { flex:0 0 auto; margin-top: 2px; }
+
+.event-detail-container .meta-item svg {
+    flex: 0 0 auto;
+    margin-top: 2px;
+}
+
 .event-detail-container .meta-text {
-  display: flex; flex-direction: column; gap: 4px; line-height: 1.25;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    line-height: 1.25;
 }
+
 .event-detail-container .meta-label {
-  font-size: 12px; color: var(--sage); font-weight: 700; letter-spacing: .2px;
+    font-size: 12px;
+    color: var(--sage);
+    font-weight: 700;
+    letter-spacing: .2px;
 }
+
 .event-detail-container .meta-value {
-  font-size: 15px; color: #222; font-weight: 600; letter-spacing: .1px;
+    font-size: 15px;
+    color: #222;
+    font-weight: 600;
+    letter-spacing: .1px;
+    word-break: break-word;
 }
 
-/* ===== AI 요약: 화이트 카드 + 크림 포인트 */
+/* ===== AI 요약 ===== */
 .event-detail-container .ed-ai-summary {
-  background: #fff;
-  border: 1px solid #e9eee9;
-  border-left: 6px solid var(--cream);
-  border-radius: 12px;
-  padding: 14px 16px;
-  margin-bottom: 16px;
-  box-shadow: 0 2px 10px rgba(0,0,0,.04);
-}
-.event-detail-container .ed-ai-summary .ai-badge {
-  display: inline-block;
-  font-size: 12px; font-weight: 800;
-  color: var(--espresso);
-  background: var(--cream);
-  border: 1px solid var(--cream);
-  border-radius: 999px; padding: 2px 8px; margin-bottom: 8px;
-}
-.event-detail-container .ed-ai-summary .ai-text {
-  font-size: 0.98rem; line-height: 1.65; color: #333;
+    background: #fff;
+    border: 1px solid #e9eee9;
+    border-left: 6px solid var(--cream);
+    border-radius: 12px;
+    padding: 14px 16px;
+    margin-bottom: 16px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, .04);
 }
 
-/* ===== 주최자: 한 겹 카드 추가 (HostCard 평평하게) */
-.event-detail-container .ed-organizer { margin-bottom: 16px; }
+.event-detail-container .ed-ai-summary .ai-badge {
+    display: inline-block;
+    font-size: 12px;
+    font-weight: 800;
+    color: var(--espresso);
+    background: var(--cream);
+    border: 1px solid var(--cream);
+    border-radius: 999px;
+    padding: 2px 8px;
+    margin-bottom: 8px;
+}
+
+.event-detail-container .ed-ai-summary .ai-text {
+    font-size: 0.98rem;
+    line-height: 1.65;
+    color: #333;
+}
+
+/* ===== 주최자 카드 래퍼 ===== */
+.event-detail-container .ed-organizer {
+    margin-bottom: 16px;
+}
+
 .event-detail-container .ed-org-card {
-  background: #fff;
-  border: 1px solid #e9eee9;
-  border-radius: 12px;
-  padding: 12px;
-  box-shadow: 0 2px 10px rgba(0,0,0,.04);
+    background: #fff;
+    border: 1px solid #e9eee9;
+    border-radius: 12px;
+    padding: 12px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, .04);
 }
+
 .event-detail-container .ed-org-card .org-card {
-  background: transparent !important; border: 0 !important;
-  box-shadow: none !important; padding: 0 !important;
+    background: transparent !important;
+    border: 0 !important;
+    box-shadow: none !important;
+    padding: 0 !important;
 }
+
 .event-detail-container .ed-org-card .org-card__header {
-  display: flex; align-items: center; gap: 10px; padding: 0;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 0;
 }
+
 .event-detail-container .ed-org-card .org-card__avatar {
-  width: 40px !important; height: 40px !important;
-  border-radius: 50%; overflow: hidden;
-  background: #eef5f0; display: grid; place-items: center;
-  color: #5E936C; font-weight: 800;
+    width: 40px !important;
+    height: 40px !important;
+    border-radius: 50%;
+    overflow: hidden;
+    background: #eef5f0;
+    display: grid;
+    place-items: center;
+    color: #5E936C;
+    font-weight: 800;
 }
-.event-detail-container .ed-org-card .org-card__name { font-weight: 800; color: #5E936C; }
-.event-detail-container .ed-org-card .unsubscribe-btn { display: none !important; }
+
+.event-detail-container .ed-org-card .org-card__name {
+    font-weight: 800;
+    color: #5E936C;
+}
+
+.event-detail-container .ed-org-card .unsubscribe-btn {
+    display: none !important;
+}
 
 /* ===== 상세 본문 ===== */
 .event-detail-container .ed-body {
-  background: #fff; border: 1px solid #e9eee9; border-radius: 12px;
-  padding: 16px; box-shadow: 0 2px 10px rgba(0,0,0,.04); margin-bottom: 20px;
+    background: #fff;
+    border: 1px solid #e9eee9;
+    border-radius: 12px;
+    padding: 16px;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, .04);
+    margin-bottom: 20px;
 }
-.event-detail-container .ed-h2 { font-size: 1.1rem; color:#1f2d23; margin-bottom:10px; }
-.event-detail-container .event-description { font-size: 0.98rem; line-height: 1.7; color:#333; }
+
+.event-detail-container .ed-h2 {
+    font-size: 1.1rem;
+    color: #1f2d23;
+    margin-bottom: 10px;
+}
+
+.event-detail-container .event-description {
+    font-size: 0.98rem;
+    line-height: 1.7;
+    color: #333;
+}
 
 /* ===== 액션 ===== */
-.event-detail-container .event-actions { margin-top: 8px; display:flex; gap:12px; }
-.event-detail-container .btn {
-  padding: 10px 16px; border: none; border-radius: 8px; color:#fff;
-  cursor: pointer; box-shadow: 0 2px 10px rgba(0,0,0,.06);
+.event-detail-container .event-actions {
+    margin-top: 8px;
+    display: flex;
+    gap: 12px;
 }
-.event-detail-container .edit-btn   { background: #5E936C; }
-.event-detail-container .review-btn { background: #5E936C; }
+
+.event-detail-container .btn {
+    padding: 10px 16px;
+    border: none;
+    border-radius: 8px;
+    color: #fff;
+    cursor: pointer;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, .06);
+}
+
+.event-detail-container .edit-btn {
+    background: #5E936C;
+}
+
+.event-detail-container .review-btn {
+    background: #5E936C;
+}
 
 /* ===== 리뷰 모달 ===== */
 .event-detail-container .review-popup {
-  position: fixed; inset: 0; background: rgba(0,0,0,0.5);
-  display:flex; justify-content:center; align-items:center; z-index: 1000;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1000;
 }
+
 .event-detail-container .review-content {
-  background: #fff; padding: 20px; width: 520px; max-height: 80%;
-  overflow-y: auto; border-radius: 12px; position: relative;
-  box-shadow: 0 10px 40px rgba(0,0,0,.15);
+    background: #fff;
+    padding: 20px;
+    width: 520px;
+    max-height: 80%;
+    overflow-y: auto;
+    border-radius: 12px;
+    position: relative;
+    box-shadow: 0 10px 40px rgba(0, 0, 0, .15);
 }
-.event-detail-container .close-btn { position: absolute; top:10px; right:10px; border:none; background:none; font-size:1.2rem; cursor:pointer; }
-.event-detail-container .review-list { margin-top:16px; }
-.event-detail-container .review-item { border-bottom:1px solid #eee; padding:10px 0; }
-.event-detail-container .review-user { font-weight:800; color:#5E936C; }
-.event-detail-container .review-text { margin-top:6px; font-size:0.95rem; line-height:1.5; }
+
+.event-detail-container .close-btn {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    border: none;
+    background: none;
+    font-size: 1.2rem;
+    cursor: pointer;
+}
+
+.event-detail-container .review-list {
+    margin-top: 16px;
+}
+
+.event-detail-container .review-item {
+    border-bottom: 1px solid #eee;
+    padding: 10px 0;
+}
+
+.event-detail-container .review-user {
+    font-weight: 800;
+    color: #5E936C;
+}
+
+.event-detail-container .review-text {
+    margin-top: 6px;
+    font-size: 0.95rem;
+    line-height: 1.5;
+}
 
 /* ===== 이미지 라이트박스 ===== */
 .event-detail-container .ed-img-modal {
-  position: fixed; inset: 0; background: rgba(0,0,0,0.7);
-  display:flex; justify-content:center; align-items:center; z-index: 1100; cursor: zoom-out;
-}
-.event-detail-container .ed-img-box { position: relative; max-width: 90vw; max-height: 90vh; }
-.event-detail-container .ed-img-box img { width: 100%; height: 100%; object-fit: contain; display:block; border-radius: 8px; }
-.event-detail-container .ed-img-close {
-  position: absolute; top: 8px; right: 8px;
-  border: none; background: rgba(0,0,0,0.45); color:#fff;
-  border-radius: 999px; width: 36px; height: 36px; cursor: pointer;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.7);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 1100;
+    cursor: zoom-out;
 }
 
-/* ===== 반응형 ===== */
+.event-detail-container .ed-img-box {
+    position: relative;
+    max-width: 90vw;
+    max-height: 90vh;
+}
+
+.event-detail-container .ed-img-box img {
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    display: block;
+    border-radius: 8px;
+}
+
+.event-detail-container .ed-img-close {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    border: none;
+    background: rgba(0, 0, 0, 0.45);
+    color: #fff;
+    border-radius: 999px;
+    width: 36px;
+    height: 36px;
+    cursor: pointer;
+}
+
+/* ===== 반응형 (모바일 전용: 폰트/여백 한 단계 축소) ===== */
+@media (max-width: 768px) {
+    .event-detail-container {
+        padding: 16px 14px 28px;
+    }
+
+    /* Hero */
+    .event-detail-container .ed-cover-caption {
+        font-size: 11px;
+    }
+
+    .event-detail-container .ed-bookmark {
+        width: 34px;
+        height: 34px;
+        top: 8px;
+        right: 8px;
+    }
+
+    /* 타이틀 */
+    .event-detail-container .event-title {
+        font-size: 1.3rem;
+    }
+
+    /* 태그 */
+    .event-detail-container .ed-tag {
+        font-size: 11px;
+        padding: 5px 8px;
+        margin-right: 5px;
+    }
+
+    /* 메타 */
+    .event-detail-container .ed-meta-grid.two-by-two {
+        gap: 12px;
+        padding: 12px;
+    }
+
+    .event-detail-container .meta-label {
+        font-size: 11px;
+    }
+
+    .event-detail-container .meta-value {
+        font-size: 13px;
+    }
+
+    /* AI 요약/본문 */
+    .event-detail-container .ed-ai-summary .ai-text {
+        font-size: 0.9rem;
+        line-height: 1.6;
+    }
+
+    .event-detail-container .ed-h2 {
+        font-size: 1rem;
+    }
+
+    .event-detail-container .event-description {
+        font-size: 0.92rem;
+        line-height: 1.6;
+    }
+
+    /* 액션 버튼 한 줄이 너무 길면 세로 배치 */
+    .event-detail-container .event-actions {
+        flex-direction: column;
+    }
+
+    .event-detail-container .btn {
+        width: 100%;
+        text-align: center;
+    }
+
+    /* 라이트박스 여유 */
+    .event-detail-container .review-content {
+        width: 92%;
+    }
+
+    .event-detail-container .ed-img-box {
+        max-width: 94vw;
+    }
+}
+
+/* 기존 640px 규칙 유지하되, 위 768px 규칙이 먼저 적용되어 더 일찍 작아집니다 */
 @media (max-width: 640px) {
-  .event-detail-container { padding: 16px 16px 32px; }
-  .event-detail-container .event-title { font-size: 1.5rem; }
-  .event-detail-container .event-actions { flex-direction: column; }
-  .event-detail-container .btn { width: 100%; text-align: center; }
-  .event-detail-container .review-content { width: 92%; }
+    .event-detail-container {
+        padding: 16px 16px 32px;
+    }
+
+    .event-detail-container .event-title {
+        font-size: 1.25rem;
+    }
 }

--- a/front/src/css/eventupload.css
+++ b/front/src/css/eventupload.css
@@ -1,8 +1,10 @@
+/* eventupload.css — 가로 스크롤 제거용 사이즈/레이아웃 수정본 (JSX 변경 불필요) */
 .eventupload-container {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   margin: 0;
   padding: 0;
   box-sizing: border-box;
+  overflow-x: hidden; /* 🔒 이 페이지에서만 수평 스크롤 방지 */
 }
 
 .eventupload-container *,
@@ -11,21 +13,24 @@
   box-sizing: inherit;
 }
 
-/* PC 버전 스타일 */
+/* =============== PC =============== */
 @media (min-width: 769px) {
-   .eventupload-container {    
-    width: 90vw;           
+  .eventupload-container {
+    /* ⬇️ 90vw 제거 → 레이아웃 최대폭 레일 안으로 */
+    max-width: var(--content-max-width, 1200px);
+    width: 100%;
     min-width: 340px;
     margin: 0 auto;
     padding-top: 20px;
-    overflow: hidden;
-
+    padding-left: var(--content-padding-x, 24px);
+    padding-right: var(--content-padding-x, 24px);
+    overflow-x: hidden;
   }
 
   /* PC 헤더 */
   .eventupload-header {
     position: sticky;
-    top: 0;
+    top: 0; /* 필요 시 var(--topbar-height)로 조정 가능 */
     background: white;
     padding: 24px 32px;
     border-bottom: 1px solid #f0f0f0;
@@ -45,16 +50,12 @@
     justify-content: center;
     border-radius: 12px;
     transition: all 0.2s ease;
-
   }
-
-  .eventupload-back-button:hover {
-
-    transform: translateY(-1px);
-  }
+  .eventupload-back-button:hover { transform: translateY(-1px); }
 
   /* PC 스텝 콘텐츠 */
   .eventupload-step-content {
+    position: relative;           /* ✅ 하단바 absolute 기준점 */
     padding: 40px 32px 120px;
     opacity: 0;
     transform: translateY(20px);
@@ -62,16 +63,16 @@
     min-height: 500px;
     display: flex;
     flex-direction: column;
+    overflow-x: hidden;           /* 안전장치 */
   }
-
   .eventupload-step-content.show {
     opacity: 1;
     transform: translateY(0);
   }
 
-  /* 제목 크기 고정 */
+  /* 제목 */
   .eventupload-title {
-    font-size: 28px; 
+    font-size: 28px;
     font-weight: 700;
     line-height: 1.3;
     color: #191f28;
@@ -85,7 +86,6 @@
     grid-template-columns: 1fr 1fr;
     gap: 20px;
   }
-
   .eventupload-mode-card {
     padding: 32px 24px;
     border: 2px solid #e9ecef;
@@ -100,14 +100,12 @@
     gap: 16px;
     min-height: 200px;
   }
-
   .eventupload-mode-card:hover {
     border-color: #5E936C;
     background: #f8fbf9;
     transform: translateY(-2px);
     box-shadow: 0 8px 24px rgba(94, 147, 108, 0.15);
   }
-
   .eventupload-mode-card.selected {
     border-color: #5E936C;
     background: #f8fbf9;
@@ -116,22 +114,7 @@
   }
 
   /* PC 입력 필드 */
-  .eventupload-input {
-    width: 100%;
-    padding: 24px;
-    font-size: 20px;
-    border: 2px solid #e9ecef;
-    border-radius: 16px;
-    background: white;
-    transition: all 0.2s ease;
-    outline: none;
-  }
-
-  .eventupload-input:focus {
-    border-color: #5E936C;
-    box-shadow: 0 0 0 3px rgba(94, 147, 108, 0.1);
-  }
-
+  .eventupload-input,
   .eventupload-textarea {
     width: 100%;
     padding: 24px;
@@ -141,22 +124,26 @@
     background: white;
     transition: all 0.2s ease;
     outline: none;
+  }
+  .eventupload-input:focus,
+  .eventupload-textarea:focus {
+    border-color: #5E936C;
+    box-shadow: 0 0 0 3px rgba(94, 147, 108, 0.1);
+  }
+  .eventupload-textarea {
     resize: vertical;
     min-height: 140px;
     font-family: inherit;
   }
 
-  .eventupload-textarea:focus {
-    border-color: #5E936C;
-    box-shadow: 0 0 0 3px rgba(94, 147, 108, 0.1);
-  }
-
-  /* PC 하단 버튼 */
+  /* ✅ PC 하단 버튼 바: 컨테이너 너비만큼만 */
   .eventupload-bottom {
     position: absolute;
     bottom: 0;
     left: 0;
-    width: 100%;
+    right: 0;               /* ✅ width:auto와 세트 → padding 포함해도 오버플로우 X */
+    width: auto;            /* ✅ 100% + padding으로 넘치던 문제 해결 */
+    box-sizing: border-box; /* ✅ 패딩 포함 계산 */
     padding: 24px 32px;
     background: white;
     border-top: 1px solid #f0f0f0;
@@ -179,14 +166,12 @@
     justify-content: center;
     gap: 8px;
   }
-
   .eventupload-next-button.active {
     background: #5E936C;
     color: white;
     cursor: pointer;
     box-shadow: 0 4px 16px rgba(94, 147, 108, 0.3);
   }
-
   .eventupload-next-button.active:hover {
     background: #4a7a57;
     transform: translateY(-2px);
@@ -194,20 +179,22 @@
   }
 }
 
-/* 모바일 버전 스타일 */
+/* =============== 모바일 =============== */
 @media (max-width: 768px) {
   .eventupload-container {
     width: 100%;
     background: white;
     border-radius: 0;
-     padding-top: 48px
+    padding-top: 48px;
+    padding-left: 16px;   /* 레이아웃 여백과 일치 */
+    padding-right: 16px;
+    overflow-x: hidden;
   }
-
 
   /* 모바일 헤더 */
   .eventupload-header {
     position: sticky;
-    top: 0;
+    top: 0; /* 필요 시 calc(var(--topbar-height-mobile) + env(safe-area-inset-top, 0px)) */
     background: white;
     padding: 16px 20px;
     border-bottom: 1px solid #f0f0f0;
@@ -230,11 +217,7 @@
     transition: background-color 0.2s ease;
     color: #495057;
   }
-
-  .eventupload-back-button:hover {
-    background-color: #f8f9fa;
-  }
-
+  .eventupload-back-button:hover { background-color: #f8f9fa; }
   .eventupload-back-button:active {
     background-color: #e9ecef;
     transform: scale(0.95);
@@ -242,6 +225,7 @@
 
   /* 모바일 스텝 콘텐츠 */
   .eventupload-step-content {
+    position: relative;           /* ✅ 하단바 anchor */
     padding: 32px 20px 120px;
     opacity: 0;
     transform: translateY(20px);
@@ -249,14 +233,14 @@
     min-height: calc(100vh - 120px);
     display: flex;
     flex-direction: column;
+    overflow-x: hidden;
   }
-
   .eventupload-step-content.show {
     opacity: 1;
     transform: translateY(0);
   }
 
-  /* 제목 크기 고정 */
+  /* 제목 */
   .eventupload-title {
     font-size: 22px;
     font-weight: 700;
@@ -272,9 +256,6 @@
     flex-direction: column;
     gap: 12px;
   }
-
-
-
   .eventupload-mode-card {
     padding: 20px;
     border: 2px solid #e9ecef;
@@ -287,16 +268,11 @@
     gap: 16px;
     font-size: 10px;
   }
-
-  .eventupload-mode-card:active {
-    transform: scale(0.98);
-  }
-
+  .eventupload-mode-card:active { transform: scale(0.98); }
   .eventupload-mode-card:hover {
     border-color: #5E936C;
     background: #f8fbf9;
   }
-
   .eventupload-mode-card.selected {
     border-color: #5E936C;
     background: #f8fbf9;
@@ -304,22 +280,7 @@
   }
 
   /* 모바일 입력 필드 */
-  .eventupload-input {
-    width: 100%;
-    padding: 18px;
-    font-size: 16px;
-    border: 2px solid #e9ecef;
-    border-radius: 12px;
-    background: white;
-    transition: border-color 0.2s ease;
-    outline: none;
-    -webkit-appearance: none;
-  }
-
-  .eventupload-input:focus {
-    border-color: #5E936C;
-  }
-
+  .eventupload-input,
   .eventupload-textarea {
     width: 100%;
     padding: 18px;
@@ -329,16 +290,31 @@
     background: white;
     transition: border-color 0.2s ease;
     outline: none;
-    resize: vertical;
-    min-height: 120px;
-    font-family: inherit;
     -webkit-appearance: none;
   }
-
+  .eventupload-input:focus,
   .eventupload-textarea:focus {
     border-color: #5E936C;
   }
+  .eventupload-textarea {
+    resize: vertical;
+    min-height: 120px;
+    font-family: inherit;
+  }
 
+  /* ✅ 모바일 하단 버튼 바도 부모 폭에 맞춤 */
+  .eventupload-bottom {
+    position: absolute;
+    bottom: 0;
+    left: 0;
+    right: 0;           /* ✅ */
+    width: auto;        /* ✅ */
+    box-sizing: border-box;
+    padding: 16px 20px;
+    background: white;
+    border-top: 1px solid #f0f0f0;
+    border-radius: 0 0 16px 16px;
+  }
 
   .eventupload-next-button {
     width: 100%;
@@ -354,19 +330,15 @@
     justify-content: center;
     gap: 8px;
   }
-
   .eventupload-next-button.active {
     background: #5E936C;
     color: white;
     cursor: pointer;
   }
-
-  .eventupload-next-button:active {
-    transform: scale(0.98);
-  }
+  .eventupload-next-button:active { transform: scale(0.98); }
 }
 
-/* 공통 스타일 */
+/* =============== 공통 =============== */
 .eventupload-progress-bar {
   flex: 1;
   height: 4px;
@@ -374,7 +346,6 @@
   border-radius: 2px;
   overflow: hidden;
 }
-
 .eventupload-progress-fill {
   height: 100%;
   background: #5E936C;
@@ -382,27 +353,14 @@
   transition: width 0.3s ease;
 }
 
-.eventupload-question {
-  flex: 1;
-}
-
-.eventupload-input-group {
-  margin-top: 8px;
-}
+.eventupload-question { flex: 1; }
+.eventupload-input-group { margin-top: 8px; }
 
 .eventupload-input::placeholder,
-.eventupload-textarea::placeholder {
-  color: #adb5bd;
-}
+.eventupload-textarea::placeholder { color: #adb5bd; }
 
-.eventupload-mode-icon {
-  color: #5E936C;
-  flex-shrink: 0;
-}
-
-.eventupload-ai-icon {
-  font-size: 32px;
-}
+.eventupload-mode-icon { color: #5E936C; flex-shrink: 0; }
+.eventupload-ai-icon { font-size: 32px; }
 
 .eventupload-mode-title {
   font-size: 15px;
@@ -410,17 +368,13 @@
   color: #191f28;
   margin-bottom: 4px;
 }
-
 .eventupload-mode-desc {
   font-size: 14px;
   color: #8b95a1;
   line-height: 1.4;
 }
 
-.eventupload-ai-result {
-  flex: 1;
-}
-
+.eventupload-ai-result { flex: 1; }
 .eventupload-ai-content-card {
   background: white;
   border: 1px solid #e9ecef;
@@ -428,11 +382,7 @@
   padding: 24px;
   margin-bottom: 24px;
 }
-
-.eventupload-ai-content {
-  position: relative;
-}
-
+.eventupload-ai-content { position: relative; }
 .eventupload-ai-text {
   font-size: 16px;
   line-height: 1.6;
@@ -450,18 +400,9 @@
   cursor: pointer;
   transition: all 0.2s ease;
 }
+.eventupload-edit-button:hover { background: #5E936C; color: white; }
 
-.eventupload-edit-button:hover {
-  background: #5E936C;
-  color: white;
-}
-
-.eventupload-edit-container {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
+.eventupload-edit-container { display: flex; flex-direction: column; gap: 12px; }
 .eventupload-edit-textarea {
   width: 100%;
   padding: 16px;
@@ -473,48 +414,20 @@
   outline: none;
   font-family: inherit;
 }
+.eventupload-edit-textarea:focus { border-color: #5E936C; }
 
-.eventupload-edit-textarea:focus {
-  border-color: #5E936C;
-}
-
-.eventupload-edit-buttons {
-  display: flex;
-  gap: 8px;
-}
-
+.eventupload-edit-buttons { display: flex; gap: 8px; }
 .eventupload-edit-save {
-  background: #5E936C;
-  color: white;
-  border: none;
-  padding: 8px 16px;
-  border-radius: 6px;
-  font-size: 14px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  transition: background-color 0.2s ease;
+  background: #5E936C; color: white; border: none;
+  padding: 8px 16px; border-radius: 6px; font-size: 14px; cursor: pointer;
+  display: flex; align-items: center; gap: 4px; transition: background-color 0.2s ease;
 }
-
-.eventupload-edit-save:hover {
-  background: #4a7a57;
-}
-
+.eventupload-edit-save:hover { background: #4a7a57; }
 .eventupload-edit-cancel {
-  background: white;
-  color: #666;
-  border: 1px solid #e9ecef;
-  padding: 8px 16px;
-  border-radius: 6px;
-  font-size: 14px;
-  cursor: pointer;
-  transition: all 0.2s ease;
+  background: white; color: #666; border: 1px solid #e9ecef;
+  padding: 8px 16px; border-radius: 6px; font-size: 14px; cursor: pointer; transition: all 0.2s ease;
 }
-
-.eventupload-edit-cancel:hover {
-  background: #f8f9fa;
-}
+.eventupload-edit-cancel:hover { background: #f8f9fa; }
 
 .eventupload-summary-card {
   background: #f8fbf9;
@@ -523,57 +436,18 @@
   padding: 24px;
   margin-bottom: 32px;
 }
-
-.eventupload-summary-title {
-  font-size: 18px;
-  font-weight: 600;
-  color: #333;
-  margin-bottom: 16px;
-}
-
-.eventupload-summary-list {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
+.eventupload-summary-title { font-size: 18px; font-weight: 600; color: #333; margin-bottom: 16px; }
+.eventupload-summary-list { display: flex; flex-direction: column; gap: 12px; }
 .eventupload-summary-item {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 0;
-  border-bottom: 1px solid #e9ecef;
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 12px 0; border-bottom: 1px solid #e9ecef;
 }
-
-.eventupload-summary-item:last-child {
-  border-bottom: none;
-}
-
-.eventupload-summary-label {
-  font-size: 14px;
-  color: #666;
-  font-weight: 500;
-}
-
-.eventupload-summary-value {
-  font-size: 16px;
-  color: #333;
-  font-weight: 600;
-}
+.eventupload-summary-item:last-child { border-bottom: none; }
+.eventupload-summary-label { font-size: 14px; color: #666; font-weight: 500; }
+.eventupload-summary-value { font-size: 16px; color: #333; font-weight: 600; }
 
 .eventupload-submit-button {
-  width: 100%;
-  padding: 18px;
-  background: #5E936C;
-  color: white;
-  border: none;
-  border-radius: 12px;
-  font-size: 16px;
-  font-weight: 600;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
+  width: 100%; padding: 18px; background: #5E936C; color: white; border: none;
+  border-radius: 12px; font-size: 16px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease;
 }
-
-.eventupload-submit-button:hover {
-  background: #4a7a57;
-}
+.eventupload-submit-button:hover { background: #4a7a57; }

--- a/front/src/css/eventupload.css
+++ b/front/src/css/eventupload.css
@@ -1,10 +1,10 @@
-/* eventupload.css — 가로 스크롤 제거용 사이즈/레이아웃 수정본 (JSX 변경 불필요) */
+
 .eventupload-container {
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
   margin: 0;
   padding: 0;
   box-sizing: border-box;
-  overflow-x: hidden; /* 🔒 이 페이지에서만 수평 스크롤 방지 */
+  overflow-x: hidden;
 }
 
 .eventupload-container *,
@@ -16,7 +16,7 @@
 /* =============== PC =============== */
 @media (min-width: 769px) {
   .eventupload-container {
-    /* ⬇️ 90vw 제거 → 레이아웃 최대폭 레일 안으로 */
+ 
     max-width: var(--content-max-width, 1200px);
     width: 100%;
     min-width: 340px;
@@ -30,7 +30,8 @@
   /* PC 헤더 */
   .eventupload-header {
     position: sticky;
-    top: 0; /* 필요 시 var(--topbar-height)로 조정 가능 */
+    top: 0;
+    /* 필요 시 var(--topbar-height)로 조정 가능 */
     background: white;
     padding: 24px 32px;
     border-bottom: 1px solid #f0f0f0;
@@ -51,11 +52,15 @@
     border-radius: 12px;
     transition: all 0.2s ease;
   }
-  .eventupload-back-button:hover { transform: translateY(-1px); }
+
+  .eventupload-back-button:hover {
+    transform: translateY(-1px);
+  }
 
   /* PC 스텝 콘텐츠 */
   .eventupload-step-content {
-    position: relative;           /* ✅ 하단바 absolute 기준점 */
+    position: relative;
+
     padding: 40px 32px 120px;
     opacity: 0;
     transform: translateY(20px);
@@ -63,8 +68,10 @@
     min-height: 500px;
     display: flex;
     flex-direction: column;
-    overflow-x: hidden;           /* 안전장치 */
+    overflow-x: hidden;
+    /* 안전장치 */
   }
+
   .eventupload-step-content.show {
     opacity: 1;
     transform: translateY(0);
@@ -86,6 +93,7 @@
     grid-template-columns: 1fr 1fr;
     gap: 20px;
   }
+
   .eventupload-mode-card {
     padding: 32px 24px;
     border: 2px solid #e9ecef;
@@ -100,12 +108,14 @@
     gap: 16px;
     min-height: 200px;
   }
+
   .eventupload-mode-card:hover {
     border-color: #5E936C;
     background: #f8fbf9;
     transform: translateY(-2px);
     box-shadow: 0 8px 24px rgba(94, 147, 108, 0.15);
   }
+
   .eventupload-mode-card.selected {
     border-color: #5E936C;
     background: #f8fbf9;
@@ -125,25 +135,27 @@
     transition: all 0.2s ease;
     outline: none;
   }
+
   .eventupload-input:focus,
   .eventupload-textarea:focus {
     border-color: #5E936C;
     box-shadow: 0 0 0 3px rgba(94, 147, 108, 0.1);
   }
+
   .eventupload-textarea {
     resize: vertical;
     min-height: 140px;
     font-family: inherit;
   }
 
-  /* ✅ PC 하단 버튼 바: 컨테이너 너비만큼만 */
+
   .eventupload-bottom {
     position: absolute;
     bottom: 0;
     left: 0;
-    right: 0;               /* ✅ width:auto와 세트 → padding 포함해도 오버플로우 X */
-    width: auto;            /* ✅ 100% + padding으로 넘치던 문제 해결 */
-    box-sizing: border-box; /* ✅ 패딩 포함 계산 */
+    right: 0;
+    width: auto;
+    box-sizing: border-box;
     padding: 24px 32px;
     background: white;
     border-top: 1px solid #f0f0f0;
@@ -166,12 +178,14 @@
     justify-content: center;
     gap: 8px;
   }
+
   .eventupload-next-button.active {
     background: #5E936C;
     color: white;
     cursor: pointer;
     box-shadow: 0 4px 16px rgba(94, 147, 108, 0.3);
   }
+
   .eventupload-next-button.active:hover {
     background: #4a7a57;
     transform: translateY(-2px);
@@ -186,7 +200,8 @@
     background: white;
     border-radius: 0;
     padding-top: 48px;
-    padding-left: 16px;   /* 레이아웃 여백과 일치 */
+    padding-left: 16px;
+    /* 레이아웃 여백과 일치 */
     padding-right: 16px;
     overflow-x: hidden;
   }
@@ -194,7 +209,8 @@
   /* 모바일 헤더 */
   .eventupload-header {
     position: sticky;
-    top: 0; /* 필요 시 calc(var(--topbar-height-mobile) + env(safe-area-inset-top, 0px)) */
+    top: 0;
+    /* 필요 시 calc(var(--topbar-height-mobile) + env(safe-area-inset-top, 0px)) */
     background: white;
     padding: 16px 20px;
     border-bottom: 1px solid #f0f0f0;
@@ -217,7 +233,11 @@
     transition: background-color 0.2s ease;
     color: #495057;
   }
-  .eventupload-back-button:hover { background-color: #f8f9fa; }
+
+  .eventupload-back-button:hover {
+    background-color: #f8f9fa;
+  }
+
   .eventupload-back-button:active {
     background-color: #e9ecef;
     transform: scale(0.95);
@@ -225,7 +245,8 @@
 
   /* 모바일 스텝 콘텐츠 */
   .eventupload-step-content {
-    position: relative;           /* ✅ 하단바 anchor */
+    position: relative;
+    /* ✅ 하단바 anchor */
     padding: 32px 20px 120px;
     opacity: 0;
     transform: translateY(20px);
@@ -235,6 +256,7 @@
     flex-direction: column;
     overflow-x: hidden;
   }
+
   .eventupload-step-content.show {
     opacity: 1;
     transform: translateY(0);
@@ -256,6 +278,7 @@
     flex-direction: column;
     gap: 12px;
   }
+
   .eventupload-mode-card {
     padding: 20px;
     border: 2px solid #e9ecef;
@@ -268,11 +291,16 @@
     gap: 16px;
     font-size: 10px;
   }
-  .eventupload-mode-card:active { transform: scale(0.98); }
+
+  .eventupload-mode-card:active {
+    transform: scale(0.98);
+  }
+
   .eventupload-mode-card:hover {
     border-color: #5E936C;
     background: #f8fbf9;
   }
+
   .eventupload-mode-card.selected {
     border-color: #5E936C;
     background: #f8fbf9;
@@ -292,23 +320,24 @@
     outline: none;
     -webkit-appearance: none;
   }
+
   .eventupload-input:focus,
   .eventupload-textarea:focus {
     border-color: #5E936C;
   }
+
   .eventupload-textarea {
     resize: vertical;
     min-height: 120px;
     font-family: inherit;
   }
 
-  /* ✅ 모바일 하단 버튼 바도 부모 폭에 맞춤 */
   .eventupload-bottom {
     position: absolute;
     bottom: 0;
     left: 0;
-    right: 0;           /* ✅ */
-    width: auto;        /* ✅ */
+    right: 0;
+    width: auto;
     box-sizing: border-box;
     padding: 16px 20px;
     background: white;
@@ -330,12 +359,16 @@
     justify-content: center;
     gap: 8px;
   }
+
   .eventupload-next-button.active {
     background: #5E936C;
     color: white;
     cursor: pointer;
   }
-  .eventupload-next-button:active { transform: scale(0.98); }
+
+  .eventupload-next-button:active {
+    transform: scale(0.98);
+  }
 }
 
 /* =============== 공통 =============== */
@@ -346,6 +379,7 @@
   border-radius: 2px;
   overflow: hidden;
 }
+
 .eventupload-progress-fill {
   height: 100%;
   background: #5E936C;
@@ -353,14 +387,27 @@
   transition: width 0.3s ease;
 }
 
-.eventupload-question { flex: 1; }
-.eventupload-input-group { margin-top: 8px; }
+.eventupload-question {
+  flex: 1;
+}
+
+.eventupload-input-group {
+  margin-top: 8px;
+}
 
 .eventupload-input::placeholder,
-.eventupload-textarea::placeholder { color: #adb5bd; }
+.eventupload-textarea::placeholder {
+  color: #adb5bd;
+}
 
-.eventupload-mode-icon { color: #5E936C; flex-shrink: 0; }
-.eventupload-ai-icon { font-size: 32px; }
+.eventupload-mode-icon {
+  color: #5E936C;
+  flex-shrink: 0;
+}
+
+.eventupload-ai-icon {
+  font-size: 32px;
+}
 
 .eventupload-mode-title {
   font-size: 15px;
@@ -368,13 +415,17 @@
   color: #191f28;
   margin-bottom: 4px;
 }
+
 .eventupload-mode-desc {
   font-size: 14px;
   color: #8b95a1;
   line-height: 1.4;
 }
 
-.eventupload-ai-result { flex: 1; }
+.eventupload-ai-result {
+  flex: 1;
+}
+
 .eventupload-ai-content-card {
   background: white;
   border: 1px solid #e9ecef;
@@ -382,7 +433,11 @@
   padding: 24px;
   margin-bottom: 24px;
 }
-.eventupload-ai-content { position: relative; }
+
+.eventupload-ai-content {
+  position: relative;
+}
+
 .eventupload-ai-text {
   font-size: 16px;
   line-height: 1.6;
@@ -400,9 +455,18 @@
   cursor: pointer;
   transition: all 0.2s ease;
 }
-.eventupload-edit-button:hover { background: #5E936C; color: white; }
 
-.eventupload-edit-container { display: flex; flex-direction: column; gap: 12px; }
+.eventupload-edit-button:hover {
+  background: #5E936C;
+  color: white;
+}
+
+.eventupload-edit-container {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .eventupload-edit-textarea {
   width: 100%;
   padding: 16px;
@@ -414,20 +478,48 @@
   outline: none;
   font-family: inherit;
 }
-.eventupload-edit-textarea:focus { border-color: #5E936C; }
 
-.eventupload-edit-buttons { display: flex; gap: 8px; }
+.eventupload-edit-textarea:focus {
+  border-color: #5E936C;
+}
+
+.eventupload-edit-buttons {
+  display: flex;
+  gap: 8px;
+}
+
 .eventupload-edit-save {
-  background: #5E936C; color: white; border: none;
-  padding: 8px 16px; border-radius: 6px; font-size: 14px; cursor: pointer;
-  display: flex; align-items: center; gap: 4px; transition: background-color 0.2s ease;
+  background: #5E936C;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  transition: background-color 0.2s ease;
 }
-.eventupload-edit-save:hover { background: #4a7a57; }
+
+.eventupload-edit-save:hover {
+  background: #4a7a57;
+}
+
 .eventupload-edit-cancel {
-  background: white; color: #666; border: 1px solid #e9ecef;
-  padding: 8px 16px; border-radius: 6px; font-size: 14px; cursor: pointer; transition: all 0.2s ease;
+  background: white;
+  color: #666;
+  border: 1px solid #e9ecef;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: all 0.2s ease;
 }
-.eventupload-edit-cancel:hover { background: #f8f9fa; }
+
+.eventupload-edit-cancel:hover {
+  background: #f8f9fa;
+}
 
 .eventupload-summary-card {
   background: #f8fbf9;
@@ -436,18 +528,57 @@
   padding: 24px;
   margin-bottom: 32px;
 }
-.eventupload-summary-title { font-size: 18px; font-weight: 600; color: #333; margin-bottom: 16px; }
-.eventupload-summary-list { display: flex; flex-direction: column; gap: 12px; }
-.eventupload-summary-item {
-  display: flex; justify-content: space-between; align-items: center;
-  padding: 12px 0; border-bottom: 1px solid #e9ecef;
+
+.eventupload-summary-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #333;
+  margin-bottom: 16px;
 }
-.eventupload-summary-item:last-child { border-bottom: none; }
-.eventupload-summary-label { font-size: 14px; color: #666; font-weight: 500; }
-.eventupload-summary-value { font-size: 16px; color: #333; font-weight: 600; }
+
+.eventupload-summary-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.eventupload-summary-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid #e9ecef;
+}
+
+.eventupload-summary-item:last-child {
+  border-bottom: none;
+}
+
+.eventupload-summary-label {
+  font-size: 14px;
+  color: #666;
+  font-weight: 500;
+}
+
+.eventupload-summary-value {
+  font-size: 16px;
+  color: #333;
+  font-weight: 600;
+}
 
 .eventupload-submit-button {
-  width: 100%; padding: 18px; background: #5E936C; color: white; border: none;
-  border-radius: 12px; font-size: 16px; font-weight: 600; cursor: pointer; transition: background-color 0.2s ease;
+  width: 100%;
+  padding: 18px;
+  background: #5E936C;
+  color: white;
+  border: none;
+  border-radius: 12px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background-color 0.2s ease;
 }
-.eventupload-submit-button:hover { background: #4a7a57; }
+
+.eventupload-submit-button:hover {
+  background: #4a7a57;
+}

--- a/front/src/css/hostcard.css
+++ b/front/src/css/hostcard.css
@@ -1,6 +1,4 @@
-/* HostCard 전용 스타일 — 페이지 CSS와 분리 */
 
-/* 카드 */
 .org-card {
   background: #fff;
   border: 1px solid #E9ECEF;
@@ -102,7 +100,6 @@
   .unsubscribe-btn .label-hover   { display: none !important; }
 }
 
-/* ===== 반응형(모바일에서 더 작게 & 깔끔하게) ===== */
 @media (max-width: 768px){
   .org-card { padding: 12px; gap: 10px; }
   .org-card__header { gap: 10px; }

--- a/front/src/css/hostcard.css
+++ b/front/src/css/hostcard.css
@@ -11,13 +11,14 @@
   gap: 12px;
   transition: transform .12s ease, box-shadow .12s ease, background .12s ease;
   cursor: pointer;
+  touch-action: manipulation;
 }
 .org-card:hover {
   background: #fafafa;
   transform: translateY(-1px);
   box-shadow: 0 4px 14px rgba(0,0,0,0.04);
 }
-.org-card.is-mock { cursor: default; } /* 목업카드는 클릭 이동 없음 */
+.org-card.is-mock { cursor: default; }
 
 /* 헤더: 아바타+이름 / 버튼 */
 .org-card__header {
@@ -25,14 +26,18 @@
   align-items: center;
   justify-content: space-between;
   gap: 12px;
+  /* 이름은 넓게, 버튼은 줄어들지 않게 */
 }
 .org-card__info {
   display: flex;
   align-items: center;
   gap: 12px;
-  min-width: 0; /* 이름 ellipsis */
+  min-width: 0;     /* ← ellipsis 작동용 */
+  flex: 1 1 auto;   /* ← 남는 공간 다 쓰기 */
 }
+.unsubscribe-btn { flex: 0 0 auto; } /* ← 버튼은 줄어들지 않게 */
 
+/* 아바타 */
 .org-card__avatar {
   width: 44px;
   height: 44px;
@@ -51,16 +56,18 @@
   object-fit: cover;
 }
 
+/* 이름 */
 .org-card__name {
   font-weight: 700;
-  font-size: 1rem;
+  font-size: 1rem;      /* ≈16px */
   line-height: 1.2;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  max-width: 100%;
 }
 
-/* 구독 상태 버튼: 기본 '구독중' / hover '구독 해제' */
+/* 구독 상태 버튼 */
 .unsubscribe-btn {
   position: relative;
   display: inline-flex;
@@ -82,7 +89,6 @@
   border-color: #BDB7A6;
   transform: translateY(-1px);
 }
-
 .unsubscribe-btn .label-default { display: inline; }
 .unsubscribe-btn .label-hover   { display: none; }
 .unsubscribe-btn:hover .label-default,
@@ -94,4 +100,33 @@
 @media (hover: none) {
   .unsubscribe-btn .label-default { display: inline !important; }
   .unsubscribe-btn .label-hover   { display: none !important; }
+}
+
+/* ===== 반응형(모바일에서 더 작게 & 깔끔하게) ===== */
+@media (max-width: 768px){
+  .org-card { padding: 12px; gap: 10px; }
+  .org-card__header { gap: 10px; }
+
+  .org-card__avatar {
+    width: 40px; height: 40px; flex-basis: 40px;
+    font-size: 0.9rem;
+  }
+  .org-card__name { font-size: 0.95rem; }          /* ≈15px */
+
+  .unsubscribe-btn {
+    padding: 6px 10px;
+    font-size: 12px;
+    gap: 4px;
+    border-radius: 999px;
+  }
+}
+
+@media (max-width: 380px){
+  .org-card { padding: 10px; }
+  .org-card__avatar {
+    width: 36px; height: 36px; flex-basis: 36px;
+    font-size: 0.85rem;
+  }
+  .org-card__name { font-size: 0.9rem; }           /* ≈14px */
+  .unsubscribe-btn { padding: 5px 9px; font-size: 11.5px; }
 }

--- a/front/src/css/hostdetail.css
+++ b/front/src/css/hostdetail.css
@@ -16,7 +16,7 @@
   color: var(--fg);
   padding: 16px 0;
   min-height: 100vh;
-  overflow-x: hidden; /* 🔒 가로 스크롤 방지 */
+  overflow-x: hidden; 
 }
 
 /* 중앙 래퍼: 부모 .layout-inner 최대폭 준수 */
@@ -142,7 +142,7 @@
   .host-events-section{ margin-top: 18px; }
   .section-title{ margin: 0 0 14px; }
   .event-grid{
-    grid-template-columns: repeat(2, minmax(0, 1fr)); /* ✅ 2열 고정으로 안전 */
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 12px;
   }
 }

--- a/front/src/css/hostdetail.css
+++ b/front/src/css/hostdetail.css
@@ -8,39 +8,31 @@
   --accent: #F27B50;
   --olive: #5E936C;
   --olive-hover: #347a47;
-
-  /* 상단 고정바 추정 높이(프로젝트에 맞게 64~88 조절) */
-  --topbar-h: 72px;
 }
 
 /* 페이지 컨테이너 */
 .host-detail {
   background: var(--bg);
   color: var(--fg);
-  padding: 16px 0; /* 좌우 0 */
-  min-height: calc(100vh - 64px);
+  padding: 16px 0;
+  min-height: 100vh;
+  overflow-x: hidden; /* 🔒 가로 스크롤 방지 */
 }
 
-/* ✅ 모바일: TopBar 높이만큼 위 여백(+ 안전영역) */
-@media (max-width: 768px) {
-  .host-detail {
-    padding-top: calc(var(--topbar-h) + env(safe-area-inset-top, 0px));
-    padding-bottom: 0;
-    min-height: 100vh;
-  }
-}
-
-/* 중앙 래퍼 */
+/* 중앙 래퍼: 부모 .layout-inner 최대폭 준수 */
 .hd-inner {
-  max-width: none;
-  margin: 0;
+  max-width: 100%;
+  width: 100%;
+  margin: 0 auto;
   padding: 0;
   display: grid;
   gap: 18px;
+  box-sizing: border-box;
 }
 
 /* 상단 프로필 카드 */
 .hero-card {
+  width: 100%;
   overflow: visible;
   position: relative;
   display: grid;
@@ -49,8 +41,9 @@
   background: var(--card);
   border: 1px solid var(--line);
   border-radius: 14px;
-  padding: 12px 12px 12px 108px; /* ← 아바타 공간 넉넉하게 */
-  min-height: 78px;
+  padding: 12px 24px 12px 108px; /* 우측 여백 확보 */
+  min-height: 120px;
+  box-sizing: border-box;
 }
 
 .host-detail .card-overlap .avatar-xxl {
@@ -61,7 +54,6 @@
   width: 72px;
   height: 72px;
   aspect-ratio: 1/1;
-  box-sizing: content-box;
   border-radius: 50%;
   background: var(--brand);
   color: #fff;
@@ -74,35 +66,14 @@
   overflow: hidden;
 }
 .host-detail .card-overlap .avatar-xxl img {
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: cover; /* 원형 내부 꽉 채우기 */
+  width: 100%; height: 100%; object-fit: cover; display: block;
 }
 
-.hero-content {
-  min-width: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 6px; /* 이름 ↔ 별점 간격 */
-}
+.hero-content { min-width: 0; display: flex; flex-direction: column; gap: 6px; }
+.host-title { margin: 0 0 2px 0; font-weight: 800; font-size: 1.45rem; line-height: 1.1; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.host-stars-row { color: #F2B544; letter-spacing: .5px; font-size: .95rem; }
 
-.host-title {
-  margin: 0 0 2px 0;
-  font-weight: 800;
-  font-size: 1.45rem;
-  line-height: 1.1;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-.host-stars-row {
-  color: #F2B544;
-  letter-spacing: .5px;
-  font-size: .95rem;
-}
-
-/* 구독 버튼 + 라벨 스위치 */
+/* 구독 버튼 */
 .pill-subscribe {
   justify-self: end;
   background: #E9E2CF;
@@ -116,18 +87,16 @@
   cursor: pointer;
   white-space: nowrap;
   transition: transform .15s ease, background .2s ease;
+  margin-right: 14px; /* 오른쪽 너무 붙지 않도록 */
 }
 .pill-subscribe.on { background: #D8D0BB; }
 .pill-subscribe:hover { transform: translateY(-1px); }
-
 .pill-subscribe .ps-label-default { display: inline; }
 .pill-subscribe .ps-label-hover   { display: none; }
 .pill-subscribe.on:hover .ps-label-default,
 .pill-subscribe.on:focus-visible .ps-label-default { display: none; }
 .pill-subscribe.on:hover .ps-label-hover,
 .pill-subscribe.on:focus-visible .ps-label-hover   { display: inline; }
-
-/* 모바일(hover: none)에서는 기본 라벨만 */
 @media (hover: none) {
   .pill-subscribe.on .ps-label-default { display: inline !important; }
   .pill-subscribe.on .ps-label-hover   { display: none !important; }
@@ -141,52 +110,39 @@
   padding: 12px 14px;
   display: grid;
   gap: 8px;
-  margin-bottom: 20px; /* ↓ 카드 섹션과 간격 */
+  margin-bottom: 20px;
+  box-sizing: border-box;
 }
-.ai-badge {
-  display: inline-block;
-  background: #F2ECD8;
-  color: var(--fg);
-  padding: 6px 10px;
-  border-radius: 8px;
-  font-size: .9rem;
-}
+.ai-badge { display: inline-block; background: #F2ECD8; color: var(--fg); padding: 6px 10px; border-radius: 8px; font-size: .9rem; }
 .ai-badge strong { color: var(--brand); }
 .ai-summary-txt { margin: 0; line-height: 1.55; }
 
-/* 주최자 행사 목록 */
-.host-events-section { margin-top: 24px; } /* 6px → 24px */
-.section-title {
-  font-size: 1.1rem;
-  font-weight: 800;
-  margin: 0 0 18px; /* 6px 0 10px → 0 0 18px */
-}
-/* 제목과 그리드가 붙어 보일 때 한 번 더 안전하게 */
+/* 섹션 */
+.host-events-section { margin-top: 24px; }
+.section-title { font-size: 1.1rem; font-weight: 800; margin: 0 0 18px; }
 .host-events-section .event-grid { margin-top: 6px; }
 
-/* 카드 그리드 */
-.event-grid {
+/* 이벤트 카드 그리드 (절대 넘치지 않게) */
+.event-grid{
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 20px;
+  width: 100%;
+  box-sizing: border-box;
 }
-@media (max-width: 1024px) {
-  .event-grid { grid-template-columns: repeat(3, 1fr); }
+.event-grid > * { min-width: 0; }
+
+@media (max-width: 1024px){
+  .event-grid{ gap: 18px; }
 }
-@media (max-width: 768px) {
-  .event-grid { grid-template-columns: repeat(2, 1fr); }
-}
-
-/* 기타 */
-.stars { display: inline-block; }
-
-/* 모바일에서 패딩/간격 미세 조정 */
-@media (max-width: 768px) {
-  .hero-card { padding: 10px 10px 10px 96px; }
-  .hero-content { gap: 4px; }
-
-  .ai-summary-card { margin-bottom: 16px; }
-  .host-events-section { margin-top: 18px; }
-  .section-title { margin: 0 0 14px; }
-  .host-events-section .event-grid { margin-top: 4px; }
+@media (max-width: 768px){
+  .hero-card{ padding: 10px 16px 10px 96px; }
+  .hero-content{ gap: 4px; }
+  .ai-summary-card{ margin-bottom: 16px; }
+  .host-events-section{ margin-top: 18px; }
+  .section-title{ margin: 0 0 14px; }
+  .event-grid{
+    grid-template-columns: repeat(2, minmax(0, 1fr)); /* ✅ 2열 고정으로 안전 */
+    gap: 12px;
+  }
 }

--- a/front/src/css/layout.css
+++ b/front/src/css/layout.css
@@ -1,94 +1,72 @@
-:root {
-  --sidebar-w: 240px;
-  --topbar-h: 64px;
+/* src/css/layout.css */
+:root{
+  --sidebar-width: 336px;
+  --topbar-height: 64px;        /* 데스크탑 탑바 */
+  --topbar-height-mobile: 56px; /* 모바일 탑바 */
+  --bottombar-height: 64px;     /* 모바일 하단바 (BottomBar와 동일) */
 
-
-  --gutter-d: 40px;
-  --gutter-t: 24px;
-  --gutter-m: 16px;
-  --content-max: 1180px;
+  --content-max-width: 1200px;
+  --content-padding-x: 24px;
 }
 
-.layout-container {
-  display: flex;
-  height: 100vh;
-  overflow: hidden;
+/* 기본 리셋 */
+html, body, #root { height: 100%; }
+html, body { margin: 0; padding: 0; }
+* { box-sizing: border-box; }
+
+body { overflow-x: hidden; }     /* 가로 스크롤 방지 */
+
+/* 컨테이너 */
+.layout-container{ min-height: 100vh; position: relative; }
+.layout-main-content{
+  /* 데스크탑: 탑바 높이만큼만 위 패딩 */
+  min-height: calc(100vh - var(--topbar-height));
+  padding-top: var(--topbar-height);
+  box-sizing: border-box;
+}
+.layout-inner{
+  max-width: var(--content-max-width);
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 var(--content-padding-x);
+  overflow-x: clip;              /* 내부 컴포넌트가 잠깐 커져도 가로 스크롤 차단 */
 }
 
-
-.layout-main-content {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: auto;
-  background: #fff;
+/* 데스크탑: 사이드바 fixed → 왼쪽 여백 필요 */
+@media (min-width: 769px){
+  .layout-main-content.with-layout{ padding-left: var(--sidebar-width); }
 }
 
+/* ===== 모바일 ===== */
+@media (max-width: 768px){
+  .layout-main-content{
+    /* 모바일 브라우저 주소창 변화 대응: 100dvh 사용 */
+    min-height: calc(100dvh - var(--topbar-height-mobile));
+    padding-top: var(--topbar-height-mobile);
+    padding-left: 0;
+    margin: 0 !important;
+  }
 
-.layout-main-content.with-layout {
-  margin-left: var(--sidebar-w);
-  padding-top: var(--topbar-h);
-  padding-left: var(--gutter-d);
-  padding-right: var(--gutter-d);
+  /* 하단바가 fixed라서 내용이 가려지지 않도록 아래 패딩 추가 */
+  .layout-container.mobile .layout-main-content.with-layout{
+    padding-bottom: calc(var(--bottombar-height) + env(safe-area-inset-bottom, 0px));
+  }
+
+  .layout-inner{ padding: 0 16px; }
 }
 
-
-.layout-main-content.without-layout {
-  margin-left: 0;
+/* 레이아웃 비적용 페이지(로그인 등) */
+.layout-main-content.without-layout{
   padding-top: 0;
-  padding-left: var(--gutter-m);
-  padding-right: var(--gutter-m);
+  padding-left: 0;
 }
 
-
-.layout-main-content.with-layout>.subscribe-page,
-.layout-main-content.with-layout>.host-detail,
-.layout-main-content.with-layout>.dashboard-page,
-.layout-main-content.with-layout>.page-root {
-  width: 100%;
-  max-width: var(--content-max);
-  margin-inline: auto;
+/* ===== 페이지별 중복 top-padding을 전역에서 무력화 (모바일) ===== */
+@media (max-width: 768px){
+  .layout-main-content .eventupload-container{ padding-top: 0 !important; }
+  .layout-main-content .host-detail{           padding-top: 0 !important; }
+  .layout-main-content .subscribe-page{        padding-top: 0 !important; }
 }
 
-.layout-main-content.without-layout>.subscribe-page,
-.layout-main-content.without-layout>.host-detail,
-.layout-main-content.without-layout>.dashboard-page,
-.layout-main-content.without-layout>.page-root {
-  width: 100%;
-  max-width: var(--content-max);
-  margin-inline: auto;
-}
-
-
-@media (max-width: 1024px) {
-  .layout-main-content.with-layout {
-    margin-left: 0;
-    padding-top: var(--topbar-h);
-    padding-left: var(--gutter-t);
-    padding-right: var(--gutter-t);
-  }
-}
-
-@media (max-width: 768px) {
-
-  .layout-main-content.with-layout,
-  .layout-main-content.without-layout {
-    margin-left: 0;
-    padding-top: 0;
-    padding-left: var(--gutter-m);
-    padding-right: var(--gutter-m);
-  }
-}
-
-
-@media (min-width: 1440px) {
-  :root {
-    --content-max: 1240px;
-  }
-}
-
-@media (min-width: 1680px) {
-  :root {
-    --content-max: 1320px;
-  }
-}
+/* 첫 요소가 불필요한 margin-top을 갖는 경우 대비 */
+.layout-inner > *:first-child{ margin-top: 0; }

--- a/front/src/css/layout.css
+++ b/front/src/css/layout.css
@@ -1,72 +1,49 @@
-/* src/css/layout.css */
 :root{
   --sidebar-width: 336px;
-  --topbar-height: 64px;        /* 데스크탑 탑바 */
-  --topbar-height-mobile: 56px; /* 모바일 탑바 */
-  --bottombar-height: 64px;     /* 모바일 하단바 (BottomBar와 동일) */
+  --topbar-height: 64px;
+  --topbar-height-mobile: 56px;
 
+  /* ✅ 모든 페이지 공통 최대 폭/패딩 */
   --content-max-width: 1200px;
   --content-padding-x: 24px;
 }
 
-/* 기본 리셋 */
-html, body, #root { height: 100%; }
-html, body { margin: 0; padding: 0; }
-* { box-sizing: border-box; }
+/* 전역: 기본 마진/수평 스크롤 제거 */
+html, body { margin: 0; padding: 0; width: 100%; overflow-x: hidden; }
 
-body { overflow-x: hidden; }     /* 가로 스크롤 방지 */
-
-/* 컨테이너 */
 .layout-container{ min-height: 100vh; position: relative; }
+.layout-main-content,
+.layout-container { overflow-x: hidden; }
+
+/* 데스크탑: 탑바 공간 확보 */
 .layout-main-content{
-  /* 데스크탑: 탑바 높이만큼만 위 패딩 */
   min-height: calc(100vh - var(--topbar-height));
   padding-top: var(--topbar-height);
-  box-sizing: border-box;
 }
+
+/* ✅ 중앙 정렬 컨테이너 */
 .layout-inner{
   max-width: var(--content-max-width);
   width: 100%;
   margin: 0 auto;
   padding: 0 var(--content-padding-x);
-  overflow-x: clip;              /* 내부 컴포넌트가 잠깐 커져도 가로 스크롤 차단 */
+  box-sizing: border-box;
 }
 
-/* 데스크탑: 사이드바 fixed → 왼쪽 여백 필요 */
+/* PC: 사이드바 fixed → 왼쪽 패딩 */
 @media (min-width: 769px){
   .layout-main-content.with-layout{ padding-left: var(--sidebar-width); }
 }
 
-/* ===== 모바일 ===== */
+/* 모바일: 사이드바 없음 + 모바일 탑바 높이/안전영역 포함 */
 @media (max-width: 768px){
   .layout-main-content{
-    /* 모바일 브라우저 주소창 변화 대응: 100dvh 사용 */
-    min-height: calc(100dvh - var(--topbar-height-mobile));
-    padding-top: var(--topbar-height-mobile);
+    min-height: calc(100vh - (var(--topbar-height-mobile) + env(safe-area-inset-top, 0px)));
+    padding-top: calc(var(--topbar-height-mobile) + env(safe-area-inset-top, 0px));
     padding-left: 0;
-    margin: 0 !important;
   }
-
-  /* 하단바가 fixed라서 내용이 가려지지 않도록 아래 패딩 추가 */
-  .layout-container.mobile .layout-main-content.with-layout{
-    padding-bottom: calc(var(--bottombar-height) + env(safe-area-inset-bottom, 0px));
-  }
-
   .layout-inner{ padding: 0 16px; }
 }
 
-/* 레이아웃 비적용 페이지(로그인 등) */
-.layout-main-content.without-layout{
-  padding-top: 0;
-  padding-left: 0;
-}
-
-/* ===== 페이지별 중복 top-padding을 전역에서 무력화 (모바일) ===== */
-@media (max-width: 768px){
-  .layout-main-content .eventupload-container{ padding-top: 0 !important; }
-  .layout-main-content .host-detail{           padding-top: 0 !important; }
-  .layout-main-content .subscribe-page{        padding-top: 0 !important; }
-}
-
-/* 첫 요소가 불필요한 margin-top을 갖는 경우 대비 */
-.layout-inner > *:first-child{ margin-top: 0; }
+/* 레이아웃 없는 페이지 */
+.layout-main-content.without-layout{ padding-top: 0; padding-left: 0; }

--- a/front/src/css/sidebar.css
+++ b/front/src/css/sidebar.css
@@ -1,222 +1,99 @@
-/* Sidebar 컴포넌트 독립 스타일 */
-.sidebar-container {
-  width: 240px;
+:root{
+  --sidebar-width: 336px;
+  --sidebar-border: #e9ecef;
+  --brand: #5E936C;
+  --active: #939E91;
+  --text-strong: #1b1f23;
+  --text-muted: #6c757d;
+  --hover-bg: #eef2ee;
+}
+
+.sidebar-container{
+  width: var(--sidebar-width); min-width: var(--sidebar-width);
   height: 100vh;
-  background: white;
-  border-right: 1px solid #e9ecef;
-  position: fixed;
-  left: 0;
-  top: 0;
-  z-index: 900;
-  display: flex;
-  flex-direction: column;
+  background: linear-gradient(180deg, #ffffff 0%, #f5faf6 100%);
+  border-right: 1px solid var(--sidebar-border);
+  position: fixed; left: 0; top: 0; z-index: 900;
+  display: grid; grid-template-rows: auto 1fr auto;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  overflow-y: auto;
+  overflow-y: auto; padding: 16px 14px;
 }
 
-/* 사용자 정보 헤더 */
-.sidebar-header {
-  padding: 24px 20px 20px;
-  border-bottom: 1px solid #f0f0f0;
+/* 상단 블록 */
+.sidebar-top{ display: grid; gap: 12px; margin-bottom: 6px; }
+
+/* ✅ 로고만 중앙 정렬 + 더 크게 */
+.sidebar-brand{
+  display:flex; align-items:center; justify-content:center;
+  padding: 10px 0 8px;
+  cursor:pointer; border-radius:12px;
+}
+.sidebar-brand:focus-visible{ outline:2px solid var(--brand); outline-offset:2px; }
+.sidebar-logo{ width: 64px; height: 64px; object-fit: contain; display:block; }
+.sidebar-logo--lg{ width: 92px; height: 92px; }  /* ← 더 크게 */
+
+/* (이제 텍스트 안 씀) .sidebar-brand-text 는 제거 가능 */
+
+/* 프로필 카드 */
+.sidebar-user-card.rich{
+  display:flex; align-items:center; gap:12px;
+  padding:14px 16px; border-radius:16px;
+  background: linear-gradient(135deg, rgba(94,147,108,0.14), rgba(94,147,108,0.06)), #ffffff;
+  border:1px solid rgba(94,147,108,0.25);
+  box-shadow: 0 10px 24px rgba(94,147,108,0.18);
+}
+.sidebar-user-avatar{
+  width:48px; height:48px; border-radius:50%;
+  background: var(--brand); color:#fff;
+  display:flex; align-items:center; justify-content:center; font-weight:800;
+}
+.sidebar-user-avatar.xl{ width:60px; height:60px; font-size:20px; }
+.sidebar-user-details{ display:flex; flex-direction:column; gap:3px; min-width:0; }
+.sidebar-user-name{ font-size:15px; font-weight:800; color:var(--text-strong); white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.sidebar-user-name.xl{ font-size:16px; }
+.sidebar-meta-text{ font-size:12px; color:var(--text-muted); }
+.sidebar-meta-text.strong{ color:#2f3a31; font-weight:600; }
+
+/* 메뉴 */
+.sidebar-nav{ padding:10px 6px; display:flex; flex-direction:column; gap:8px; }
+.sidebar-section.compact{ padding:8px 8px 12px; }
+.sidebar-section-title{
+  font-size:12px; font-weight:800; color:#98a1a1;
+  text-transform:uppercase; letter-spacing:.6px; margin:10px 6px 10px;
 }
 
-.sidebar-user-info {
-  display: flex;
-  align-items: center;
-  gap: 12px;
+.sidebar-nav-item{
+  width:100%; background:transparent; border:none; text-align:left; color:var(--text-muted);
+  display:flex; align-items:center; gap:12px;
+  padding:12px 14px; border-radius:14px; cursor:pointer;
+  transition: background .18s ease, color .18s ease, box-shadow .18s ease;
+  font-size:15px;
+}
+.sidebar-nav-item:hover{ background: var(--hover-bg); color:#3b403b; }
+
+/* 활성 스타일 */
+.sidebar-nav-item.active,
+.sidebar-nav-item[aria-current="page"]{
+  background: var(--active); color:#fff;
+  box-shadow: 0 6px 16px rgba(147,158,145,.35);
+}
+.sidebar-nav-item.active svg,
+.sidebar-nav-item[aria-current="page"] svg{ stroke:#fff; }
+
+.sidebar-nav-label{
+  flex:1; min-width:0; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
 }
 
-.sidebar-user-avatar {
-  width: 40px;
-  height: 40px;
-  background: #5E936C;
-  color: white;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 16px;
-  font-weight: 600;
-  flex-shrink: 0;
+/* 하단 */
+.sidebar-bottom{ padding:12px 8px 8px; display:grid; gap:10px; }
+.sidebar-logout-btn{
+  width:100%; padding:12px 14px; background:transparent; border:1px solid transparent;
+  color:var(--text-muted); font-size:15px; cursor:pointer; display:flex; align-items:center; gap:10px;
+  border-radius:12px; transition: all .18s ease;
 }
+.sidebar-logout-btn:hover{ background: var(--hover-bg); color: var(--brand); border-color: var(--brand); }
 
-.sidebar-user-details {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-}
-
-.sidebar-user-name {
-  font-size: 16px;
-  font-weight: 600;
-  color: #191f28;
-}
-
-.sidebar-user-status {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.sidebar-status-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: #28a745;
-}
-
-.sidebar-status-dot.online {
-  background: #28a745;
-}
-
-.sidebar-status-text {
-  font-size: 12px;
-  color: #6c757d;
-}
-
-.sidebar-user-level {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
-.sidebar-level-dot {
-  width: 6px;
-  height: 6px;
-  border-radius: 50%;
-  background: #5E936C;
-}
-
-.sidebar-level-text {
-  font-size: 12px;
-  color: #6c757d;
-}
-
-/* 섹션 */
-.sidebar-section {
-  padding: 20px 20px 16px;
-}
-
-.sidebar-section-title {
-  font-size: 12px;
-  font-weight: 600;
-  color: #8b95a1;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin: 0 0 12px 0;
-}
-
-/* 행사 만들기 버튼 */
-.sidebar-create-btn {
-  width: 100%;
-  padding: 12px 16px;
-  background: #5E936C;
-  color: white;
-  border: none;
-  border-radius: 8px;
-  font-size: 14px;
-  font-weight: 500;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  justify-content: center;
-  transition: background-color 0.2s ease;
-}
-
-.sidebar-create-btn:hover {
-  background: #4a7a57;
-}
-
-/* 네비게이션 */
-.sidebar-nav {
-  flex: 1;
-  padding: 0 12px;
-}
-
-.sidebar-nav-item {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
-  border-radius: 8px;
-  cursor: pointer;
-  transition: all 0.2s ease;
-  color: #6c757d;
-  position: relative;
-  margin-bottom: 4px;
-}
-
-.sidebar-nav-item:hover {
-  background: #f8f9fa;
-  color: #495057;
-}
-
-.sidebar-nav-item.active {
-  background: #f8fbf9;
-  color: #5E936C;
-  font-weight: 500;
-}
-
-.sidebar-nav-item.active::before {
-  content: '';
-  position: absolute;
-  left: 0;
-  top: 50%;
-  transform: translateY(-50%);
-  width: 3px;
-  height: 20px;
-  background: #5E936C;
-  border-radius: 0 2px 2px 0;
-}
-
-.sidebar-nav-label {
-  flex: 1;
-  font-size: 14px;
-}
-
-.sidebar-nav-badge {
-  background: #dc3545;
-  color: white;
-  font-size: 11px;
-  font-weight: 600;
-  padding: 2px 6px;
-  border-radius: 10px;
-  min-width: 16px;
-  text-align: center;
-}
-
-/* 하단 로그아웃 */
-.sidebar-footer {
-  padding: 20px;
-  border-top: 1px solid #f0f0f0;
-  margin-top: auto;
-}
-
-.sidebar-logout-btn {
-  width: 100%;
-  padding: 10px 12px;
-  background: none;
-  border: none;
-  color: #6c757d;
-  font-size: 14px;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  border-radius: 6px;
-  transition: all 0.2s ease;
-}
-
-.sidebar-logout-btn:hover {
-  background: #f8f9fa;
-  color: #dc3545;
-}
-
-/* 모바일에서 Sidebar 숨김 */
-@media (max-width: 768px) {
-  .sidebar-container {
-    display: none;
-  }
+/* 모바일 숨김 */
+@media (max-width: 768px){
+  .sidebar-container{ display:none; }
 }

--- a/front/src/css/topbar.css
+++ b/front/src/css/topbar.css
@@ -1,313 +1,108 @@
-.topbar-container {
-  width: calc(100% - 240px);
-  left: 240px;
-  height: 84px;
-  background: white;
-  border-bottom: 1px solid #e9ecef;
-  position: fixed;
-  top: 0;
-  z-index: 1000;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+:root{
+  --sidebar-width: 336px;
+  --topbar-height: 64px;
+  --topbar-height-mobile: 56px;
+
+  --brand: #5E936C;
+  --ink: #191f28;
+  --muted: #6c757d;
+  --line: #e9ecef;
+
+  --search-bg: #f3f5f4;
+  --search-border: #e6ebe7;
+  --placeholder: #adb5bd;
 }
 
-.topbar-logo-img {
-  height: 120px;
-  width: auto;
-  display: block;
-  object-fit: contain;
+/* ===== 데스크탑 ===== */
+.topbar-container{
+  position: fixed; top:0; left: var(--sidebar-width);
+  width: calc(100% - var(--sidebar-width)); height: var(--topbar-height);
+  background:#fff; border-bottom:1px solid var(--line);
+  z-index:1000; display:flex; align-items:center; box-sizing: border-box;
+  font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;
+}
+.topbar-content{
+  width:100%; height:100%; padding:0 16px 0 20px;
+  display:grid; grid-template-columns: 1fr auto; gap:16px; align-items:center;
+}
+.topbar-center{ display:flex; align-items:center; justify-content:center; }
+.topbar-right{ display:flex; align-items:center; gap:12px; }
+
+/* 공통 검색 바 */
+.topbar-search{
+  width:100%; display:flex; align-items:center; gap:10px;
+  background:var(--search-bg); border:1px solid var(--search-border);
+  border-radius:24px; padding:10px 14px; transition:all .18s ease; box-sizing: border-box;
+}
+.topbar-search--desktop{ max-width:640px; width:100%; }
+.topbar-search:focus-within{ background:#fff; border-color:var(--brand); box-shadow:0 0 0 3px rgba(94,147,108,.12); }
+.topbar-search input{ flex:1; border:none; outline:none; background:transparent; font-size:14px; color:var(--ink); }
+.topbar-search input::placeholder{ color:var(--placeholder); }
+
+/* 검색 아이콘 기본(데스크탑) */
+.topbar-search-icon{ width:18px; height:18px; }
+
+/* 아이콘 버튼/배지 */
+.topbar-icon-btn{
+  position:relative; width:40px; height:40px; border:none; border-radius:50%;
+  background:#f8f9fa; color:#495057; display:flex; align-items:center; justify-content:center;
+  cursor:pointer; transition: background-color .18s ease, transform .06s ease;
+}
+.topbar-icon-btn:hover{ background:#eef1f1; }
+.topbar-icon-btn:active{ transform: translateY(1px); }
+.topbar-badge{
+  position:absolute; top:-3px; right:-3px; min-width:18px; height:18px; padding:0 4px;
+  background:#dc3545; color:#fff; border-radius:999px; font-size:11px; font-weight:700;
+  display:flex; align-items:center; justify-content:center; border:2px solid #fff;
 }
 
-.topbar-content {
-  height: 100%;
-  padding: 0 24px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  max-width: 100%;
-  margin: 0 auto;
-}
+/* ===== 모바일 ===== */
+@media (max-width: 768px){
+  .topbar-container{ display:none; }
 
-.topbar-left {
-  display: flex;
-  align-items: center;
-  min-width: 170px;
-}
-
-.topbar-logo {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-}
-
-.topbar-logo-icon {
-  width: 32px;
-  height: 32px;
-  background: #5E936C;
-  color: white;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 12px;
-  font-weight: 700;
-}
-
-.topbar-logo-text {
-  font-size: 12px;
-  color: #6c757d;
-  font-weight: 400;
-}
-
-.topbar-center {
-  flex: 1;
-  display: flex;
-  justify-content: center;
-}
-
-.topbar-page-title {
-  font-size: 20px;
-  font-weight: 600;
-  color: #191f28;
-  margin: 0;
-}
-
-.topbar-right {
-  display: flex;
-  align-items: center;
-  gap: 18px;
-  min-width: 340px;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-}
-
-.topbar-search-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  background: #f8f9fa;
-  border: 1px solid #e9ecef;
-  border-radius: 20px;
-  padding: 8px 16px;
-  width: 270px;
-  transition: all 0.2s;
-}
-
-.topbar-search-bar:focus-within {
-  border-color: #5E936C;
-  background: white;
-  box-shadow: 0 0 0 3px rgba(94, 147, 108, 0.1);
-}
-
-.topbar-search-bar input {
-  border: none;
-  background: none;
-  outline: none;
-  flex: 1;
-  font-size: 14px;
-  color: #495057;
-}
-
-.topbar-search-bar input::placeholder {
-  color: #adb5bd;
-}
-
-.topbar-notification-btn,
-.topbar-qr-btn {
-  position: relative;
-  width: 40px;
-  height: 40px;
-  border: none;
-  background: #f8f9fa;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  cursor: pointer;
-  transition: background-color 0.2s;
-  color: #495057;
-}
-
-.topbar-notification-btn:hover,
-.topbar-qr-btn:hover {
-  background: #e9ecef;
-}
-
-.topbar-notification-badge {
-  position: absolute;
-  top: -2px;
-  right: -2px;
-  width: 18px;
-  height: 18px;
-  background: #dc3545;
-  color: white;
-  border-radius: 50%;
-  font-size: 11px;
-  font-weight: 600;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  border: 2px solid white;
-}
-
-.topbar-user-profile {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  cursor: pointer;
-  padding: 6px;
-  border-radius: 8px;
-  transition: background-color 0.2s;
-}
-
-.topbar-user-profile:hover {
-  background: #f8f9fa;
-}
-
-.topbar-profile-avatar {
-  width: 32px;
-  height: 32px;
-  background: #5E936C;
-  color: white;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 14px;
-  font-weight: 600;
-}
-
-.topbar-profile-name {
-  font-size: 14px;
-  font-weight: 500;
-  color: #191f28;
-}
-
-.topbar-profile-role {
-  font-size: 12px;
-  color: #6c757d;
-}
-
-@media (max-width: 768px) {
-  /* PC용 탑바 숨김 */
-  .topbar-container {
-    display: none;
+  /* iOS 안전영역 포함: 높이/패딩 동기화 */
+  .topbar-mobile-container{
+    position:fixed; top:0; left:0; z-index:1000;
+    width:100%;
+    height: calc(var(--topbar-height-mobile) + env(safe-area-inset-top, 0px));
+    padding-top: env(safe-area-inset-top, 0px);
+    background:#fff; border-bottom:1px solid var(--line);
+    display:flex; align-items:center; box-sizing: border-box;
   }
 
-  /* 모바일 기본 탑바 */
-  .topbar-mobile-container {
-    width: 100%;
-    height: 48px;
-    background: white;
-    border-bottom: 1px solid #e9ecef;
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: 1000;
-    display: flex;
-    align-items: center;
-    padding: 0 12px;
-    box-sizing: border-box;
+  .topbar-mobile-content{
+    width:100%; height: calc(var(--topbar-height-mobile));
+    padding:0 10px;
+    display:grid; align-items:center; gap:8px; box-sizing: border-box;
+    grid-template-columns: 48px 1fr 96px; /* 왼쪽 / 가운데 / 오른쪽 */
   }
 
-  /* 모바일 메인 페이지 탑바 컨텐츠 (기존 UI) */
-  .topbar-mobile-content {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 8px;
-    height: 48px;
-    gap: 10px;
+  .topbar-mobile-left{ justify-self:start; display:flex; align-items:center; }
+
+  .topbar-mobile-logo-btn{
+    width:44px; height:44px; border:none; background:transparent; padding:0;
+    display:flex; align-items:center; justify-content:center; cursor:pointer;
+    line-height: 0;
+  }
+  .topbar-mobile-logo{ height: 30px; width:auto; object-fit:contain; display:block; }
+
+  /* 중앙 검색: 중앙 정렬 + 최대폭 제한(짧게) */
+  .topbar-search--mobile{
+    justify-self:center; max-width:52vw; width:100%;
+    padding:8px 12px; border-radius:20px;
+  }
+  .topbar-search--mobile input{ font-size:13px; }
+
+  /* ⬇ 모바일: 검색 아이콘을 20px로 강제(알림/QR과 시각 크기 통일) */
+  .topbar-search--mobile .topbar-search-icon{
+    width:20px !important;
+    height:20px !important;
+    flex:0 0 20px;
   }
 
-  .topbar-mobile-btn {
-    width: 38px;
-    height: 38px;
-    background: #f8f9fa;
-    border: none;
-    border-radius: 50%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: #495057;
-    font-size: 18px;
-    position: relative;
-  }
-
-  .topbar-mobile-btn:active,
-  .topbar-mobile-btn:hover {
-    background: #e9ecef;
-  }
-
-  .topbar-mobile-search {
-    flex: 1;
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    padding: 6px 10px;
-    background: #f8f9fa;
-    border-radius: 16px;
-    border: 1px solid #e9ecef;
-  }
-
-  .topbar-mobile-search input {
-    border: none;
-    background: none;
-    outline: none;
-    flex: 1;
-    font-size: 13px;
-  }
-
-  .topbar-notification-badge {
-    position: absolute;
-    top: -3px;
-    right: -3px;
-    width: 15px;
-    height: 15px;
-    background: #dc3545;
-    color: #fff;
-    border-radius: 50%;
-    font-size: 10px;
-    font-weight: 500;
-    border: 2px solid #fff;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  /* 모바일 서브페이지 탑바 (뒤로가기 + 제목) */
-  .topbar-mobile-subpage-content {
-    width: 100%;
-    display: flex;
-    align-items: center;
-    position: relative;
-  }
-
-  .topbar-mobile-back-btn {
-    width: 38px;
-    height: 38px;
-    background: #f8f9fa;
-    border: none;
-    border-radius: 50%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    color: #495057;
-    cursor: pointer;
-    flex-shrink: 0;
-  }
-
-  .topbar-mobile-page-title {
-    flex-grow: 1;
-    text-align: center;
-    font-size: 20px;
-    font-weight: 600;
-    color: #191f28;
-    user-select: none;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    margin-left: 12px;
-    margin-right: 50px; /* 뒤로가기 버튼 공간 확보 */
+  /* 오른쪽: 끝 정렬 + 최소폭 확보(아이콘 2개) */
+  .topbar-mobile-right{
+    justify-self:end; display:flex; align-items:center; justify-content:flex-end;
+    gap:8px; min-width:96px;
   }
 }

--- a/front/src/pages/EventUpload.jsx
+++ b/front/src/pages/EventUpload.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Calendar, Clock, MapPin, Users, DollarSign, FileText, ArrowLeft, Check, ChevronRight } from 'lucide-react';
-import Layout from '../components/Layout';
+import Layout from '../components/Layout'; 
 import '../css/eventupload.css';
 
 const EventUpload = () => {

--- a/front/src/pages/EventUpload.jsx
+++ b/front/src/pages/EventUpload.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Calendar, Clock, MapPin, Users, DollarSign, FileText, ArrowLeft, Check, ChevronRight } from 'lucide-react';
-import Layout from '../components/Layout'; 
+import Layout from '../components/Layout';
 import '../css/eventupload.css';
 
 const EventUpload = () => {

--- a/front/src/pages/HostDetail.jsx
+++ b/front/src/pages/HostDetail.jsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
 import Layout from '../components/Layout';
+import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import '../css/hostdetail.css';
 import EventCard from "../components/EventCard";
@@ -19,9 +19,9 @@ const MOCK_HOST = {
 };
 
 const MOCK_EVENTS = [
-  { id: 1, title: "행사 1", image: null, date: "2025-10-01", time: "10:00", location: "서울", fee: "무료", hashtags: ["디자인", "IT", "커뮤니티"] },
-  { id: 2, title: "행사 2", image: null, date: "2025-11-01", time: "15:00", location: "부산", fee: "10,000원" },
-  { id: 3, title: "행사 3", image: null, date: "2025-12-10", time: "09:00", location: "대구", fee: "무료" },
+  { id: 1, title: "행사 1", image: null, date: "2025.10.01", time: "10:00", location: "서울", fee: "무료", hashtags: ["디자인", "IT", "커뮤니티"] },
+  { id: 2, title: "행사 2", image: null, date: "2025.11.01", time: "15:00", location: "부산", fee: "10,000원" },
+  { id: 3, title: "행사 3", image: null, date: "2025.12.10", time: "09:00", location: "대구", fee: "무료" },
   { id: 4, title: "행사 4", image: null, date: "2026-01-15", time: "13:00", location: "광주", fee: "5,000원" },
   { id: 5, title: "행사 5", image: null, date: "2026-02-20", time: "14:00", location: "인천", fee: "무료" },
   { id: 6, title: "행사 6", image: null, date: "2026-03-05", time: "11:00", location: "제주", fee: "무료" },
@@ -100,7 +100,7 @@ export default function HostDetail() {
   };
 
   return (
-    <Layout pageTitle="주최자" activeMenuItem="subscribe">
+    <Layout pageTitle="주최자" activeMenuItem="subscriptions">
       <div className="host-detail">
         <div className="hd-inner">
           {/* 프로필 카드 */}

--- a/front/src/pages/HostDetail.jsx
+++ b/front/src/pages/HostDetail.jsx
@@ -1,9 +1,10 @@
+// src/pages/HostDetail.jsx
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import Layout from '../components/Layout';
 import { useParams, useNavigate } from 'react-router-dom';
 import axios from 'axios';
+import Layout from '../components/Layout';
+import EventCard from '../components/EventCard';
 import '../css/hostdetail.css';
-import EventCard from "../components/EventCard";
 
 const DEV_MOCK = true;
 const baseURL = process.env.REACT_APP_API_URL ?? '';
@@ -19,12 +20,12 @@ const MOCK_HOST = {
 };
 
 const MOCK_EVENTS = [
-  { id: 1, title: "행사 1", image: null, date: "2025.10.01", time: "10:00", location: "서울", fee: "무료", hashtags: ["디자인", "IT", "커뮤니티"] },
-  { id: 2, title: "행사 2", image: null, date: "2025.11.01", time: "15:00", location: "부산", fee: "10,000원" },
-  { id: 3, title: "행사 3", image: null, date: "2025.12.10", time: "09:00", location: "대구", fee: "무료" },
-  { id: 4, title: "행사 4", image: null, date: "2026-01-15", time: "13:00", location: "광주", fee: "5,000원" },
-  { id: 5, title: "행사 5", image: null, date: "2026-02-20", time: "14:00", location: "인천", fee: "무료" },
-  { id: 6, title: "행사 6", image: null, date: "2026-03-05", time: "11:00", location: "제주", fee: "무료" },
+  { id: 1, title: '행사 1', image: null, date: '2025-10-01', time: '10:00', location: '서울', fee: '무료', hashtags: ['디자인', 'IT', '커뮤니티'] },
+  { id: 2, title: '행사 2', image: null, date: '2025-11-01', time: '15:00', location: '부산', fee: '10,000원' },
+  { id: 3, title: '행사 3', image: null, date: '2025-12-10', time: '09:00', location: '대구', fee: '무료' },
+  { id: 4, title: '행사 4', image: null, date: '2026-01-15', time: '13:00', location: '광주', fee: '5,000원' },
+  { id: 5, title: '행사 5', image: null, date: '2026-02-20', time: '14:00', location: '인천', fee: '무료' },
+  { id: 6, title: '행사 6', image: null, date: '2026-03-05', time: '11:00', location: '제주', fee: '무료' },
 ];
 
 export default function HostDetail() {
@@ -36,8 +37,8 @@ export default function HostDetail() {
   const [subscribing, setSubscribing] = useState(false);
   const [bookmarks, setBookmarks] = useState({});
 
-  const toggleBookmark = (id) => {
-    setBookmarks(prev => ({ ...prev, [id]: !prev[id] }));
+  const toggleBookmark = (eventId) => {
+    setBookmarks((prev) => ({ ...prev, [eventId]: !prev[eventId] }));
   };
 
   const Stars = ({ value = 0 }) => {
@@ -82,7 +83,7 @@ export default function HostDetail() {
   const toggleSubscribe = async () => {
     if (!host?.id) return;
     if (DEV_MOCK || !baseURL) {
-      setIsSubscribed(s => !s);
+      setIsSubscribed((s) => !s);
       return;
     }
     try {
@@ -100,16 +101,16 @@ export default function HostDetail() {
   };
 
   return (
-    <Layout pageTitle="주최자" activeMenuItem="subscriptions">
+    <Layout pageTitle="주최자">
       <div className="host-detail">
         <div className="hd-inner">
-          {/* 프로필 카드 */}
+          {/* 상단 프로필 카드 */}
           <section className="hero-card card-overlap">
-            <div className="avatar-xxl">
+            <div className="avatar-xxl" aria-hidden="true">
               {host?.profileImage ? (
                 <img src={host.profileImage} alt={`${host?.name ?? '주최자'} 프로필`} />
               ) : (
-                (host?.name?.[0] ?? '호')
+                host?.name?.[0] ?? '호'
               )}
             </div>
 
@@ -158,7 +159,7 @@ export default function HostDetail() {
                   {...event}
                   bookmarked={bookmarks[event.id]}
                   onBookmarkToggle={() => toggleBookmark(event.id)}
-                  onClick={() => navigate(`/events/${event.id}`)} // 클릭 시 상세페이지 이동
+                  onClick={() => navigate(`/events/${event.id}`)}
                 />
               ))}
             </div>

--- a/front/src/pages/SignupPage.jsx
+++ b/front/src/pages/SignupPage.jsx
@@ -1,96 +1,120 @@
-import React, { useState, useEffect, useCallback } from 'react';
-import Layout from '../components/Layout';
-import HostCard from '../components/HostCard';
-import InfiniteScroll from 'react-infinite-scroll-component';
-import axios from 'axios';
-import '../css/subscribe.css';
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Avatar from "react-avatar";
+import { FaUserCircle } from "react-icons/fa";
+import "../css/signuppage.css"; 
+import logo from '../imgs/mainlogo.png';
 
-const PAGE_SIZE = 20;
-const baseURL = process.env.REACT_APP_API_URL ?? '';
+const SignupPage = () => {
+  const navigate = useNavigate();
 
-export default function SubscribePage() {
-  const [organizers, setOrganizers] = useState([]);
-  const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(true);
-  const [loading, setLoading] = useState(false);
-  const [errMsg, setErrMsg] = useState('');
+  const [name, setName] = useState("");
+  const [phone, setPhone] = useState("");
+  const [email, setEmail] = useState("");
+  const [nickname, setNickname] = useState("");
+  const [password, setPassword] = useState("");
+  const [profileFile, setProfileFile] = useState(null);
+  const [previewURL, setPreviewURL] = useState("");
 
-  const fetchOrganizers = useCallback(
-    async (nextPage = 1) => {
-      if (loading) return;
-      setLoading(true);
-      setErrMsg('');
-
-      try {
-        const res = await axios.get(`${baseURL}/api/organizers`, {
-          params: { page: nextPage, size: PAGE_SIZE },
-        });
-
-        const items = Array.isArray(res.data?.data)
-          ? res.data.data
-          : Array.isArray(res.data?.items)
-          ? res.data.items
-          : Array.isArray(res.data)
-          ? res.data
-          : [];
-
-        setOrganizers(prev => (nextPage === 1 ? items : [...prev, ...items]));
-        setHasMore(items.length === PAGE_SIZE);
-      } catch (e) {
-        console.error(e);
-        setErrMsg('구독 목록을 불러오는 중 문제가 발생했어요.');
-        setHasMore(false);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [loading]
-  );
-
-  useEffect(() => {
-    fetchOrganizers(1);
-  }, [fetchOrganizers]);
-
-  const loadMore = async () => {
-    const next = page + 1;
-    await fetchOrganizers(next);
-    setPage(next);
+  const handleLoginClick = () => {
+    navigate("/login");
   };
 
-  const isEmpty = (Array.isArray(organizers) ? organizers.length : 0) === 0 && !loading && !errMsg;
+  const handleFileChange = (e) => {
+    const file = e.target.files[0];
+    setProfileFile(file);
+
+    if (file) {
+      const reader = new FileReader();
+      reader.onloadend = () => setPreviewURL(reader.result);
+      reader.readAsDataURL(file);
+    } else {
+      setPreviewURL("");
+    }
+  };
+
 
   return (
-    <Layout pageTitle="구독" activeMenuItem="home">
-      <div className="subscribe-page">
-        <div className="subscribe-header">
-          <h2>구독한 주최자</h2>
-          <span className="subscribe-count">{organizers?.length ?? 0}명</span>
+    <div className="signup-container">
+        <div className="signup-header">
+            <img src={logo} className="signup-header-logo" alt="로고" />
         </div>
+      <div className="signup-inner">
+        <h1 className="signup-title">회원가입</h1>
+        <form className="signup-input-form">
+        <div className="signup-profile-section">
+            {previewURL ? (
+                <img
+                src={previewURL}
+                alt="프로필 미리보기"
+                className="signup-profile-image"
+                />
+            ) : (
+                <FaUserCircle className="signup-profile-icon" />
+            )}
 
-        {errMsg && <div className="state state--error">{errMsg}</div>}
+            <div className="signup-profile-upload-wrapper">
+                <label htmlFor="profile-upload" className="signup-profile-btn">
+                프로필 이미지 업로드
+                </label>
+                <input
+                id="profile-upload"
+                type="file"
+                accept="image/*"
+                onChange={handleFileChange}
+                className="signup-profile-input"
+                />
+            </div>
+            </div>
+          <input
+            className="signup-name"
+            type="text"
+            placeholder="이름"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
 
-        {isEmpty ? (
-          <div className="empty">
-            <div className="empty__emoji">🫥</div>
-            <div className="empty__title">구독 중인 주최자가 없어요</div>
-            <div className="empty__desc">관심 있는 주최자를 구독하면 여기에서 모아볼 수 있어요.</div>
-          </div>
-        ) : (
-          <InfiniteScroll
-            dataLength={organizers?.length ?? 0}
-            next={loadMore}
-            hasMore={hasMore}
-            loader={<div className="state state--loading">불러오는 중…</div>}
-            endMessage={<div className="state state--end">마지막입니다.</div>}
-          >
-            <ul className="org-grid">
-              {(Array.isArray(organizers) ? organizers : []).map((org, idx) => (
-                <HostCard key={org?.id ?? idx} host={org} />
-              ))}
-            </ul>
-          </InfiniteScroll>
-        )}
+          <input
+            className="signup-phone"
+            type="tel"
+            placeholder="전화번호"
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            required
+          />
+          <input
+            className="signup-email"
+            type="email"
+            placeholder="이메일"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          <input
+            className="signup-nickname"
+            type="text"
+            placeholder="닉네임"
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            required
+          />
+          <input
+            className="signup-password"
+            type="password"
+            placeholder="비밀번호"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+
+          <button className="signup-btn" type="submit">
+            회원가입
+          </button>
+        </form>
       </div>
-    </Layout>
+    </div>
   );
-}
+};
+
+export default SignupPage;

--- a/front/src/pages/SubscribePage.jsx
+++ b/front/src/pages/SubscribePage.jsx
@@ -7,7 +7,7 @@ import '../css/subscribe.css';
 
 const PAGE_SIZE = 20;
 const baseURL = process.env.REACT_APP_API_URL ?? '';
-const DEV_MOCK = true; 
+const DEV_MOCK = true;
 
 const MOCK_ORGANIZERS = [
   { id: 1, name: '라이언 스튜디오', profileImage: null },
@@ -29,14 +29,14 @@ export default function SubscribePage() {
       setErrMsg('');
 
       try {
-        // 개발 모드에서는 목업 데이터 사용
+
         if (DEV_MOCK || !baseURL) {
           setOrganizers(MOCK_ORGANIZERS);
           setHasMore(false);
+          setPage(1);
           return;
         }
 
-        // 실 API
         const res = await axios.get(`${baseURL}/api/organizers`, {
           params: { page: nextPage, size: PAGE_SIZE },
         });
@@ -44,13 +44,14 @@ export default function SubscribePage() {
         const items = Array.isArray(res.data?.data)
           ? res.data.data
           : Array.isArray(res.data?.items)
-          ? res.data.items
-          : Array.isArray(res.data)
-          ? res.data
-          : [];
+            ? res.data.items
+            : Array.isArray(res.data)
+              ? res.data
+              : [];
 
         setOrganizers(prev => (nextPage === 1 ? items : [...prev, ...items]));
         setHasMore(items.length === PAGE_SIZE);
+        setPage(nextPage);
       } catch (e) {
         console.error(e);
         setErrMsg('구독 목록을 불러오는 중 문제가 발생했어요.');
@@ -68,13 +69,10 @@ export default function SubscribePage() {
 
   const loadMore = async () => {
     if (!hasMore || loading) return;
-    const next = page + 1;
-    await fetchOrganizers(next);
-    setPage(next);
+    await fetchOrganizers(page + 1);
   };
 
-  // 구독 해제 핸들러
-  // 실제 API 호출은 없고, 목업 데이터에서만 동작
+
   const handleUnsubscribe = (id) => {
     setOrganizers(prev => prev.filter(o => (o?.id ?? o?.organizerId) !== id));
   };
@@ -83,7 +81,8 @@ export default function SubscribePage() {
   const isEmpty = count === 0 && !loading && !errMsg;
 
   return (
-    <Layout pageTitle="구독" activeMenuItem="subscrib">
+
+    <Layout pageTitle="구독">
       <div className="subscribe-page">
         <div className="subscribe-header">
           <h2>구독한 주최자</h2>
@@ -105,7 +104,12 @@ export default function SubscribePage() {
                 dataLength={count}
                 next={loadMore}
                 hasMore={hasMore}
-                loader={loading && hasMore ? <div className="state state--loading">불러오는 중…</div> : null}
+                loader={
+                  loading && hasMore ? (
+                    <div className="state state--loading">불러오는 중…</div>
+                  ) : null
+                }
+                style={{ overflow: 'visible' }}
               >
                 <ul className="org-grid">
                   {(Array.isArray(organizers) ? organizers : []).map((org, idx) => (
@@ -122,6 +126,8 @@ export default function SubscribePage() {
                 </ul>
               </InfiniteScroll>
             )}
+            {!hasMore && !loading && count > 0 && (
+              <div className="state state--end">🌟 더 많은 주최자를 구독하고 다양한 행사를 만나보세요</div>)}
           </>
         )}
       </div>

--- a/front/src/pages/SubscribePage.jsx
+++ b/front/src/pages/SubscribePage.jsx
@@ -7,7 +7,7 @@ import '../css/subscribe.css';
 
 const PAGE_SIZE = 20;
 const baseURL = process.env.REACT_APP_API_URL ?? '';
-const DEV_MOCK = true; // ✅ UI 확인용
+const DEV_MOCK = true; 
 
 const MOCK_ORGANIZERS = [
   { id: 1, name: '라이언 스튜디오', profileImage: null },
@@ -29,7 +29,7 @@ export default function SubscribePage() {
       setErrMsg('');
 
       try {
-        // ✅ DEV 목업: 깜빡임 없이 바로 채우고 끝
+        // 개발 모드에서는 목업 데이터 사용
         if (DEV_MOCK || !baseURL) {
           setOrganizers(MOCK_ORGANIZERS);
           setHasMore(false);
@@ -73,7 +73,8 @@ export default function SubscribePage() {
     setPage(next);
   };
 
-  // ✅ HostCard에서 성공적으로 해제되면 여기서 리스트에서 제거
+  // 구독 해제 핸들러
+  // 실제 API 호출은 없고, 목업 데이터에서만 동작
   const handleUnsubscribe = (id) => {
     setOrganizers(prev => prev.filter(o => (o?.id ?? o?.organizerId) !== id));
   };
@@ -82,7 +83,7 @@ export default function SubscribePage() {
   const isEmpty = count === 0 && !loading && !errMsg;
 
   return (
-    <Layout pageTitle="구독" activeMenuItem="home">
+    <Layout pageTitle="구독" activeMenuItem="subscrib">
       <div className="subscribe-page">
         <div className="subscribe-header">
           <h2>구독한 주최자</h2>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "Likelion-13th-EGSBI-FE",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
### ✅ 작업 내용
**- Layout**
  - `Layout.jsx`: 공통 `layout-inner`(max-width, 중앙정렬) 적용, 모바일에서만 `BottomBar` 노출
  - `layout.css`: 탑바/사이드바 여백 충돌 제거, 모바일 safe-area 대응, 가로 스크롤 방지
- **TopBar / Sidebar / BottomBar**
  - `TopBar.jsx`/`topbar.css`: 모바일 뒤로가기/검색바 크기 정리, 아이콘 정렬/크기 통일
  - `Sidebar.jsx`/`sidebar.css`: 로고 확대 및 상단 정렬, active 하이라이트 정확도 개선
  - `BottomBar.jsx`(신규)/`bottombar.css`: 모바일 전용 하단바(홈/위치/업로드(+)/구독/마이페이지)

### 🛠 리뷰 & 실행 확인 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 리뷰어 지정 완료
- [ ] 코드 리뷰 승인 완료
- [ ] 로컬에서 정상 실행 확인

### 📝 리뷰어 요청사항
- **다른 페이지들**(예: 로그인/회원가입/마이페이지/북마크 등)에서도  
  - 레이아웃 최대폭/여백이 일관적으로 보이는지  
  - 불필요한 상단 여백(중복 padding)이 남아있지 않은지  
  - 모바일에서 가로 스크롤이 생기지 않는지  
  확인 부탁드립니다.

### 📸 스크린샷 (필요 시 첨부)
<img width="342" height="1029" alt="image" src="https://github.com/user-attachments/assets/c2b83041-29c4-44e0-bfbd-bff667e298d2" />
<img width="400" height="55" alt="image" src="https://github.com/user-attachments/assets/fdb01930-2df3-4c62-9c96-502afa698b8e" />
<img width="396" height="62" alt="image" src="https://github.com/user-attachments/assets/af3c3543-0691-498a-875e-340782ea3e9a" />
<img width="1279" height="1007" alt="image" src="https://github.com/user-attachments/assets/726baf0d-eecc-4891-82a1-c2d29602cc8b" />
