### PR TITLE
[feat] 전체 행사 페이지 UI 작업 및 행사 카드 수정

### DIFF
--- a/front/src/App.js
+++ b/front/src/App.js
@@ -19,7 +19,7 @@ import EditProfile from './pages/EditProfile';
 import JoinedEvents from './pages/JoinedEvents';
 import EventEdit from './pages/EventEdit';
 import MainPage from './pages/InitMain';
-
+import Eventall from './pages/EventAll';
 
 function App() {
   return (
@@ -42,6 +42,7 @@ function App() {
       <Route path="/host-card" element={<HostCard />} />
       <Route path="/my-upload-event" element={<MyUploadEvent/>} />
       <Route path="/event-edit/:eventId" element={<EventEdit />} />
+      <Route path="/event-all" element={<Eventall />} />
 
 
 

--- a/front/src/css/eventall.css
+++ b/front/src/css/eventall.css
@@ -1,0 +1,160 @@
+:root {
+  --brand: #5E936C;
+  --accent: #939E91;
+  --line: #e9eee9;
+  --text-strong: #1f2d23;
+  --text-muted: #6c757d;
+}
+
+.eventall-page { padding: 30px 0 28px; }
+
+.eventall-head {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  align-items: start;
+  gap: 12px;
+  margin-bottom: 18px;
+}
+
+.eventall-count {
+  font-size: 20px;
+  font-weight: 400;
+  color: var(--text-strong);
+  line-height: 1.2;
+  margin-bottom: 6px;
+}
+.eventall-count .count-num {
+  color: var(--brand);
+  font-weight: 800;
+}
+
+.eventall-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 8px;
+  align-self: end;
+  margin-top: 6px;
+}
+
+.eventall-filters {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+.chip {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: #fff;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 11.5px;
+  font-weight: 700;
+  transition: all .15s ease;
+}
+.chip:hover { border-color: var(--accent); color: var(--accent); }
+.chip.on {
+  background: var(--accent);
+  color: #fff;
+  border-color: transparent;
+  box-shadow: 0 6px 16px rgba(147,158,145,.35);
+}
+
+.eventall-sort {
+  display: inline-flex;
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  overflow: hidden;
+  padding: 2px;
+}
+.sort-tab {
+  appearance: none;
+  border: none;
+  cursor: pointer;
+  padding: 5px 12px;
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: .2px;
+  color: var(--brand);
+  background: transparent;
+  border-radius: 999px;
+  transition: all .15s ease;
+}
+.sort-tab.active {
+  background: var(--brand);
+  color: #fff;
+  box-shadow: 0 2px 6px rgba(94,147,108,.25);
+}
+
+.eventall-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+.eventall-grid .event-card { width: 100%; }
+
+.eventall-empty {
+  padding: 32px 0;
+  color: var(--text-muted);
+  text-align: center;
+  font-weight: 700;
+}
+
+/* 페이지네이션 */
+.eventall-pagination {
+  margin-top: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6px;
+}
+.eventall-pagination .page-list {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+.page-btn {
+  appearance: none;
+  border: 1px solid var(--line);
+  background: #fff;
+  color: var(--text-strong);
+  padding: 6px 10px;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all .12s ease;
+}
+.page-btn:hover:not(:disabled) { border-color: var(--brand); color: var(--brand); }
+.page-btn.active {
+  background: var(--brand);
+  color: #fff;
+  border-color: var(--brand);
+  box-shadow: 0 4px 10px rgba(94,147,108,.25);
+}
+.page-btn.nav { border-radius: 999px; padding: 6px 12px; }
+.page-btn:disabled { opacity: .45; cursor: not-allowed; }
+.page-dots {
+  padding: 6px 10px;
+  font-size: 13px;
+  color: var(--text-muted);
+}
+
+@media (max-width: 1280px) {
+  .eventall-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+@media (max-width: 1024px) {
+  .eventall-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+@media (max-width: 768px) {
+  .eventall-head { grid-template-columns: 1fr; gap: 10px; }
+  .eventall-controls { align-items: flex-end; }
+  .eventall-grid { grid-template-columns: 1fr; }
+  .eventall-count { font-size: 18px; }
+}

--- a/front/src/css/eventcard.css
+++ b/front/src/css/eventcard.css
@@ -1,162 +1,91 @@
-/* 그리드가 hover 확장에 잘리지 않도록 */
+/* EventCard */
 .event-grid { overflow: visible; }
 
-/* ── 카드 기본 ───────────────────────────── */
 .event-card {
-  width: 280px;
+  width: 100%;
+  height: 100%;
   background: #fff;
   border-radius: 12px;
-  overflow: hidden;                    /* 위 초록/아래 흰 영역 라운드 유지 */
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0,0,0,.08);
   position: relative;
   display: flex;
   flex-direction: column;
-
-  /* 기본 상태 */
-  transform: none;
-  filter: none;
-
-  /* hover 효과(살짝 상승) */
   transition: transform .12s ease, box-shadow .12s ease;
-  will-change: transform;
-  transform-origin: center;
-  backface-visibility: hidden;
-  -webkit-font-smoothing: antialiased;
-  transform: translateZ(0);
 }
-
-.event-card:hover {
-  transform: translateY(-2px) scale(1.01);
-  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.12);
-  z-index: 10;
-}
-
-/* 블러 방지 */
+.event-card:hover { transform: translateY(-2px) scale(1.01); box-shadow: 0 10px 20px rgba(0,0,0,.12); z-index: 10; }
 .event-card, .event-card * { filter: none !important; }
 
-/* ── 북마크 버튼 ─────────────────────────── */
-.bookmark-btn {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  width: 36px;
-  height: 36px;
-  display: grid;
-  place-items: center;
-  background: rgba(0, 0, 0, 0.35);
-  border: 1px solid rgba(255, 255, 255, 0.6); /* 동그란 흰 테두리 */
-  border-radius: 50%;
-  cursor: pointer;
-  z-index: 2;
-  transition: transform .12s ease, background .12s ease, box-shadow .12s ease;
+/* 북마크 */
+.bookmark-btn{
+  position:absolute; top:10px; right:10px;
+  width:36px; height:36px; display:grid; place-items:center;
+  background:rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.6);
+  border-radius:50%; cursor:pointer; z-index:2; transition:all .12s ease;
+}
+.bookmark-btn:hover{ transform:translateY(-1px) scale(1.03); background:rgba(0,0,0,.45); box-shadow:0 4px 10px rgba(0,0,0,.25); }
+.bookmark-btn .icon{ color:#fff; font-size:18px; }
+.bookmark-btn.bookmarked .icon{ color:#E74C3C; }
+
+/* 이미지 */
+.event-image{
+  width:100%; height:180px;
+  display:flex; align-items:center; justify-content:center;
+  background:#5E936C; flex:0 0 auto;
+}
+.placeholder-text{ color:#fff; font-size:16px; font-weight:bold; }
+
+/* 본문 */
+.event-info{
+  padding:14px 12px;            /* 여백 살짝 축소 */
+  display:flex; flex-direction:column;
+  gap:4px;                       /* 제목-요약 간격 축소 */
+  flex:1 1 auto;
 }
 
-.bookmark-btn:hover {
-  transform: translateY(-1px) scale(1.03);
-  background: rgba(0, 0, 0, 0.45);
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.25);
+.event-title{
+  font-size:16px; font-weight:700; line-height:1.25; color:#111;
+  margin:0;                      /* 제목 아래 여백 제거 */
+  white-space:nowrap; overflow:hidden; text-overflow:ellipsis;
 }
 
-.bookmark-btn .icon { color: #fff; font-size: 18px; }
-.bookmark-btn.bookmarked .icon { color: #E74C3C; }
-
-/* ── 이벤트 이미지 ───────────────────────── */
-.event-image {
-  width: 100%;
-  height: 180px;                     
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  background: #5E936C;                
+/* 요약: 정확히 2줄 높이 고정 */
+.event-summary{
+  font-size:13px; color:#555; line-height:1.4;
+  display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical;
+  overflow:hidden; text-overflow:ellipsis;
+  height:calc(1.4em * 2);        /* ← min/max가 아닌 고정 height */
 }
 
-.placeholder-text { color: #fff; font-size: 16px; font-weight: bold; }
-
-/* ── 이벤트 정보 영역 ───────────────────── */
-.event-info {
-  background: #fff;
-  padding: 16px 14px;
+/* 해시태그: 정확히 2줄 높이 고정 */
+.hashtags{
+  display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical;
+  overflow:hidden;
+  line-height:1.3;
+  height:calc(1.3em * 2);        /* 2줄 공간만 확보(없으면도 동일 높이) */
 }
+.hashtag{ font-size:12px; color:#5E936C; margin-right:6px; }
 
-
-.event-title {
-  font-size: 16px;                    
-  font-weight: 700;
-  margin-bottom: 8px;
-  line-height: 1.25;
-  color: #111;
-  white-space: nowrap;               
-  overflow: hidden;
-  text-overflow: ellipsis;           
+/* 하단 메타 */
+.event-details{
+  display:grid; grid-template-columns:1fr 1fr; gap:6px;
+  margin-top:auto;               /* 항상 카드 하단에 고정 */
 }
+.detail-item{ display:flex; align-items:center; gap:6px; font-size:12px; color:#333; }
 
-.event-summary {
-  font-size: 13px;
-  color: #555;
-  margin-bottom: 8px;
-  line-height: 1.4;
-}
-
-/* 해시태그 */
-.hashtags { margin-bottom: 10px; }
-.hashtag  { font-size: 12px; color: #5E936C; margin-right: 6px; }
-
-/* 상세 정보 2x2 */
-.event-details {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 8px;
-}
-
-.detail-item {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 12px;
-  color: #333;
-}
-
-
-@media (max-width: 768px) {
-
-  .event-card { width: 100%; border-radius: 10px; }
-
-
-  .event-image { height: 132px; }
-  .placeholder-text { font-size: 14px; }
-
-  .bookmark-btn {
-    top: 8px; right: 8px;
-    width: 32px; height: 32px;
+/* 모바일 */
+@media (max-width: 768px){
+  .event-card{ border-radius:10px; }
+  .event-image{ height:132px; }
+  .bookmark-btn{ top:8px; right:8px; width:32px; height:32px; }
+  .bookmark-btn .icon{ font-size:16px; }
+  .event-info{ padding:12px 10px; gap:4px; }
+  .event-title{
+    font-size:14px; line-height:1.2;
+    white-space:normal; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical;
   }
-  .bookmark-btn .icon { font-size: 16px; }
-
-  .event-info { padding: 12px 12px; }
-
- 
-  .event-title {
-    font-size: 14px;
-    margin-bottom: 6px;
-    line-height: 1.2;
-    white-space: normal;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;      
-    -webkit-box-orient: vertical;
-  }
-
-  .event-summary {
-    font-size: 12px;
-    margin-bottom: 6px;
-    line-height: 1.35;
-    display: -webkit-box;
-    -webkit-line-clamp: 2;         
-    -webkit-box-orient: vertical;
-  }
-
-  .hashtags { margin-bottom: 8px; }
-  .hashtag  { font-size: 11px; margin-right: 6px; }
-
-  .event-details { gap: 6px; }
-  .detail-item  { font-size: 11px; gap: 4px; }
-  .detail-item svg { width: 14px; height: 14px; } 
+  .event-summary{ font-size:12px; line-height:1.35; height:calc(1.35em * 2); }
+  .hashtag{ font-size:11px; }
+  .detail-item{ font-size:11px; gap:4px; }
+  .detail-item svg{ width:14px; height:14px; }
 }

--- a/front/src/pages/EventAll.jsx
+++ b/front/src/pages/EventAll.jsx
@@ -1,0 +1,233 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Layout from "../components/Layout";
+import EventCard from "../components/EventCard";
+import { MOCK_EVENTS as RAW_EVENTS } from "./MockList";
+import "../css/eventall.css";
+
+function toDateFromYMDHM(ymd, hm) {
+  const d = new Date(ymd);
+  const [h, m] = (hm || "00:00").split(":").map(Number);
+  d.setHours(h || 0, m || 0, 0, 0);
+  return d;
+}
+function distanceKm(a, b) {
+  const toRad = (v) => (v * Math.PI) / 180;
+  const R = 6371;
+  const dLat = toRad((b.lat ?? 0) - (a.lat ?? 0));
+  const dLon = toRad((b.lng ?? 0) - (a.lng ?? 0));
+  const lat1 = toRad(a.lat ?? 0);
+  const lat2 = toRad(b.lat ?? 0);
+  const s =
+    Math.sin(dLat / 2) ** 2 +
+    Math.sin(dLon / 2) ** 2 * Math.cos(lat1) * Math.cos(lat2);
+  return 2 * R * Math.asin(Math.sqrt(s));
+}
+
+// 페이지 번호 축약(…)
+function getPageRange(totalPages, current, delta = 2) {
+  const range = [];
+  const left = Math.max(2, current - delta);
+  const right = Math.min(totalPages - 1, current + delta);
+  range.push(1);
+  if (left > 2) range.push("…");
+  for (let i = left; i <= right; i++) range.push(i);
+  if (right < totalPages - 1) range.push("…");
+  if (totalPages > 1) range.push(totalPages);
+  return range;
+}
+
+export default function EventAll() {
+  const navigate = useNavigate();
+
+  const [sort, setSort] = useState("latest");
+  const [includeClosed, setIncludeClosed] = useState(false);
+  const [bookmarks, setBookmarks] = useState({});
+  const [userPos, setUserPos] = useState({ lat: 37.5663, lng: 126.9779 });
+
+  const PER_PAGE = 40;
+  const [page, setPage] = useState(1);
+
+  const goTop = () => window.scrollTo({ top: 0, behavior: "smooth" });
+
+  useEffect(() => {
+    if (!("geolocation" in navigator)) return;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => setUserPos({ lat: pos.coords.latitude, lng: pos.coords.longitude }),
+      () => {},
+      { enableHighAccuracy: false, maximumAge: 600000, timeout: 3000 }
+    );
+  }, []);
+
+  const now = new Date();
+
+  const normalized = useMemo(() => {
+    return RAW_EVENTS.map((e) => {
+      const start = e.startsAt ? new Date(e.startsAt) : toDateFromYMDHM(e.date, e.time);
+      const end = e.endsAt ? new Date(e.endsAt) : new Date(start.getTime() + 2 * 60 * 60 * 1000);
+      const lat = e.lat ?? 37.5663;
+      const lng = e.lng ?? 126.9779;
+      return {
+        ...e,
+        _start: start,
+        _end: end,
+        _distance: distanceKm(userPos, { lat, lng }),
+        _isOngoing: now >= start && now <= end,
+      };
+    });
+  }, [userPos, now]);
+
+  const filteredAndSorted = useMemo(() => {
+    let arr = normalized;
+    if (!includeClosed) arr = arr.filter((e) => e._isOngoing || e._end >= now);
+    if (sort === "latest") arr = [...arr].sort((a, b) => b._start - a._start);
+    if (sort === "popular") arr = [...arr].sort((a, b) => (b.popularity ?? 0) - (a.popularity ?? 0));
+    if (sort === "distance") arr = [...arr].sort((a, b) => (a._distance ?? 1e9) - (b._distance ?? 1e9));
+    return arr;
+  }, [normalized, includeClosed, sort, now]);
+
+  const total = filteredAndSorted.length;
+  const totalPages = Math.max(1, Math.ceil(total / PER_PAGE));
+
+  useEffect(() => {
+    if (page > totalPages) setPage(totalPages);
+  }, [totalPages, page]);
+
+  const pageItems = useMemo(() => {
+    const start = (page - 1) * PER_PAGE;
+    return filteredAndSorted.slice(start, start + PER_PAGE);
+  }, [filteredAndSorted, page]);
+
+  // 페이지 바뀔 때 "페이지 맨 위"로
+  useEffect(() => {
+    goTop();
+  }, [page]);
+
+  const toggleBookmark = (id) =>
+    setBookmarks((prev) => ({ ...prev, [id]: !prev[id] }));
+  const onCardClick = (id) => navigate(`/events/${id}`);
+
+  const changePage = (p) => setPage(p);
+
+  return (
+    <Layout pageTitle="전체 행사" activeMenuItem="home">
+      <div className="eventall-page">
+        <div className="eventall-head">
+          <div className="eventall-count">
+            <strong className="count-num">{total.toLocaleString()}</strong>
+            개의 행사가 당신을 기다립니다
+          </div>
+
+          <div className="eventall-controls">
+            <div className="eventall-filters">
+              <button
+                type="button"
+                className={`chip ${!includeClosed ? "on" : ""}`}
+                onClick={() => {
+                  setIncludeClosed(false);
+                  setPage(1);
+                  goTop();
+                }}
+              >
+                진행중만
+              </button>
+              <button
+                type="button"
+                className={`chip ${includeClosed ? "on" : ""}`}
+                onClick={() => {
+                  setIncludeClosed(true);
+                  setPage(1);
+                  goTop();
+                }}
+              >
+                마감 포함
+              </button>
+            </div>
+
+            <div className="eventall-sort">
+              {[
+                { key: "latest", label: "최신" },
+                { key: "popular", label: "인기" },
+                { key: "distance", label: "거리순" },
+              ].map((t) => (
+                <button
+                  key={t.key}
+                  type="button"
+                  className={`sort-tab ${sort === t.key ? "active" : ""}`}
+                  onClick={() => {
+                    setSort(t.key);
+                    setPage(1);
+                    goTop();
+                  }}
+                >
+                  {t.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="eventall-grid event-grid">
+          {pageItems.map((e) => (
+            <EventCard
+              key={e.id}
+              id={e.id}
+              image={e.image}
+              title={e.title}
+              summary={e.summary}
+              hashtags={e.hashtags}
+              date={e.date}
+              time={e.time}
+              location={e.location}
+              fee={e.fee}
+              bookmarked={!!bookmarks[e.id]}
+              onBookmarkToggle={() => toggleBookmark(e.id)}
+              onClick={onCardClick}
+            />
+          ))}
+        </div>
+
+        {total === 0 && <div className="eventall-empty">조건에 맞는 행사가 없어요.</div>}
+
+        {totalPages > 1 && (
+          <div className="eventall-pagination" role="navigation" aria-label="페이지">
+            <button
+              type="button"
+              className="page-btn nav"
+              disabled={page === 1}
+              onClick={() => changePage(Math.max(1, page - 1))}
+            >
+              ◀
+            </button>
+
+            <div className="page-list">
+              {getPageRange(totalPages, page).map((p, idx) =>
+                p === "…" ? (
+                  <span key={`dots-${idx}`} className="page-dots">…</span>
+                ) : (
+                  <button
+                    key={p}
+                    type="button"
+                    className={`page-btn ${p === page ? "active" : ""}`}
+                    onClick={() => changePage(p)}
+                  >
+                    {p}
+                  </button>
+                )
+              )}
+            </div>
+
+            <button
+              type="button"
+              className="page-btn nav"
+              disabled={page === totalPages}
+              onClick={() => changePage(Math.min(totalPages, page + 1))}
+            >
+              ▶
+            </button>
+          </div>
+        )}
+      </div>
+    </Layout>
+  );
+}

--- a/front/src/pages/MockList.jsx
+++ b/front/src/pages/MockList.jsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import EventCard from '../components/EventCard';
+import '../css/eventcard.css';
+
+// 테스트용 50개 데이터 생성
+export const MOCK_EVENTS = Array.from({ length: 50 }, (_, i) => {
+  const id = 101 + i;
+  return {
+    id,
+    title: `행사 ${id}`,
+    summary: `행사 ${id}의 요약 텍스트입니다. 두 줄까지 표시되고 넘으면 ... 처리됩니다.`,
+    image: null,
+    date: `2025-12-${String((i % 28) + 1).padStart(2, "0")}`,
+    time: `${String((i % 24)).padStart(2, "0")}:${(i % 2 === 0 ? "00" : "30")}`,
+    location: ["서울", "부산", "대구", "인천", "광주"][i % 5],
+    fee: i % 3 === 0 ? "무료" : `${(i + 1) * 1000}원`,
+    hashtags: i % 2 === 0 ? ["커뮤니티", "IT"] : ["디자인"],
+    popularity: Math.floor(Math.random() * 500),
+    lat: 37.5663 + (i % 5) * 0.1,
+    lng: 126.9779 + (i % 5) * 0.1,
+  };
+});
+
+export default function MockList() {
+  const navigate = useNavigate();
+  const [bookmarks, setBookmarks] = useState({});
+  const toggleBookmark = (id) =>
+    setBookmarks((prev) => ({ ...prev, [id]: !prev[id] }));
+
+  return (
+    <div style={{ padding: 24 }}>
+      <h2>카드 클릭 → 상세로 이동 테스트</h2>
+      <div
+        className="event-grid"
+        style={{
+          display: "grid",
+          gridTemplateColumns: "repeat(auto-fill, 280px)",
+          gap: 16,
+        }}
+      >
+        {MOCK_EVENTS.map((ev) => (
+          <EventCard
+            key={ev.id}
+            id={ev.id}
+            {...ev}
+            bookmarked={!!bookmarks[ev.id]}
+            onBookmarkToggle={() => toggleBookmark(ev.id)}
+            onClick={() => navigate(`/events/${ev.id}`)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION

### ✅ 작업 내용
- 전체 이벤트 페이지 작업 (최신순/인기순/거리순 정렬, 진행중만/마감 포함 버튼 적용)
- 행사 카드 글자 및 해시태그 길이에 따라 카드 크기 조정함 → 고정된 여백 유지, 2줄 이상 시 ... 처리 추가함
- MockList 생성 -> UI 확인용 / 실제 API 연결 후 삭제


### 🛠 리뷰 & 실행 확인 체크리스트
- [ ] 커밋 컨벤션 준수
- [ ] 리뷰어 지정 완료
- [ ] 코드 리뷰 승인 완료
- [ ] 로컬에서 정상 실행 확인


### 📸 스크린샷 (필요 시 첨부)
<img width="1908" height="934" alt="image" src="https://github.com/user-attachments/assets/063ea451-6ddd-4dfe-8a16-f1730d12b00f" />

<img width="383" height="842" alt="image" src="https://github.com/user-attachments/assets/252d7891-d4ef-44c5-9806-9bfd54a85a38" />

<img width="1906" height="974" alt="image" src="https://github.com/user-attachments/assets/2aa77039-f870-42fc-89fc-9aa18719472a" />
